### PR TITLE
validate middleware for request body

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -13,6 +13,8 @@
         "@types/cookie-parser": "^1.4.7",
         "@types/uuid": "^10.0.0",
         "ajv": "^8.17.1",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^3.0.1",
         "bcrypt": "^5.1.1",
         "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.7",
@@ -1701,6 +1703,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/bcrypt": "^5.0.2",
         "@types/cookie-parser": "^1.4.7",
+        "@types/supertest": "^6.0.2",
         "@types/uuid": "^10.0.0",
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
@@ -24,6 +25,7 @@
         "pg-hstore": "^2.3.4",
         "redis": "^4.7.0",
         "sequelize": "^6.37.5",
+        "supertest": "^7.0.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -1421,6 +1423,12 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1518,6 +1526,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1578,6 +1592,28 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -1830,11 +1866,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -2125,7 +2173,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -2329,6 +2376,18 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -2337,6 +2396,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concat-map": {
@@ -2442,6 +2510,12 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "license": "MIT"
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2538,7 +2612,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -2550,6 +2623,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -2595,6 +2677,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -2760,7 +2852,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4"
@@ -2773,7 +2864,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3063,6 +3153,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
@@ -3188,6 +3284,34 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "license": "MIT",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3273,7 +3397,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3333,7 +3456,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3407,7 +3529,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -3437,7 +3558,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -3450,7 +3570,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3463,7 +3582,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3482,13 +3600,21 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -4792,7 +4918,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4829,7 +4954,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4839,7 +4963,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -5071,7 +5194,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5551,7 +5673,6 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -6002,7 +6123,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -6050,7 +6170,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -6258,6 +6377,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -39,6 +39,8 @@
     "@types/cookie-parser": "^1.4.7",
     "@types/uuid": "^10.0.0",
     "ajv": "^8.17.1",
+    "ajv-errors": "^3.0.0",
+    "ajv-formats": "^3.0.1",
     "bcrypt": "^5.1.1",
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.7",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.7",
+    "@types/supertest": "^6.0.2",
     "@types/uuid": "^10.0.0",
     "ajv": "^8.17.1",
     "ajv-errors": "^3.0.0",
@@ -50,6 +51,7 @@
     "pg-hstore": "^2.3.4",
     "redis": "^4.7.0",
     "sequelize": "^6.37.5",
+    "supertest": "^7.0.0",
     "uuid": "^10.0.0"
   }
 }

--- a/packages/backend/src/middleware/validation/schemas/userSchema.ts
+++ b/packages/backend/src/middleware/validation/schemas/userSchema.ts
@@ -1,0 +1,34 @@
+import { JSONSchemaType } from "ajv";
+
+interface User {
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+const userSchema: JSONSchemaType<User> = {
+  type: "object",
+  properties: {
+    /* Note: "username" is a custom format, see ../validate */
+    username: { type: "string", format: "username" },
+    email: { type: "string", format: "email" },
+    password: { type: "string", minLength: 5, maxLength: 256 },
+    confirmPassword: {
+      type: "string",
+      const: { $data: "1/password" } as unknown as string,
+    },
+  },
+  required: ["username", "email", "password", "confirmPassword"],
+  additionalProperties: false,
+  errorMessage: {
+    properties: {
+      username:
+        "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
+      password: "Password must NOT have fewer than 5 characters",
+      confirmPassword: "Passwords do not match",
+    },
+  },
+};
+
+export default userSchema;

--- a/packages/backend/src/middleware/validation/validate.ts
+++ b/packages/backend/src/middleware/validation/validate.ts
@@ -1,0 +1,48 @@
+import { NextFunction, Request, Response } from "express";
+import { Ajv } from "ajv";
+import addFormats from "ajv-formats";
+import addErrors from "ajv-errors";
+import userSchema from "./schemas/userSchema";
+
+const ajv = new Ajv({ allErrors: true, $data: true });
+addFormats(ajv);
+addErrors(ajv);
+
+ajv.addFormat("username", /^[0-9a-zA-Z_]{5,10}$/);
+
+/*
+  By using ajv.addSchema, we ensure that schema compilations happen only once,
+  but validations happen multiple times, this is best for performance
+  The compiled validation functions are available, for example via ajv.getSchema.
+
+  For example key "user" passed to addSchema is used to retrieve schemas.
+*/
+ajv.addSchema(userSchema, "user");
+
+/* validate is a middleware to validate request bodies. */
+const validate = (schema: string) => {
+  /*
+    ajv.getSchema returns compiled function that we later use to
+    validate the request body.
+    
+    ajv.getSchema call causes the schema compilation to happen only once,
+    on the first API call, not at the application start-up time.
+    This means the application would start a bit fast, but the first API
+    call would be a bit slower. If this is undesirable, you could,
+    for example, call ajv.getSchema for all added schemas after they are added,
+    then when ajv.getSchema is called inside route handler it would simply get
+    compiled validation function from the ajv instance cache.
+  */
+  const validate = ajv.getSchema(schema);
+  return (req: Request, res: Response, next: NextFunction) => {
+    const valid = validate && validate(req.body);
+    if (!valid) {
+      const errors = validate?.errors;
+      res.status(400).json({ error: errors });
+      return;
+    }
+    next();
+  };
+};
+
+export default validate;

--- a/packages/backend/src/router/user/index.ts
+++ b/packages/backend/src/router/user/index.ts
@@ -5,7 +5,7 @@ router.get("/", (req: Request, res: Response) => {
   res.set({
     "Content-Type": "application/json",
   });
-  res.json({ message: "Create account" });
+  res.json({ message: "Welcome, please create account / login" });
 });
 
 export default router;

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,8 +1,9 @@
 import { Router, Request, Response } from "express";
+import validate from "../../middleware/validation/validate";
 const router = Router();
 
-router.get("/", (req: Request, res: Response) => {
-  res.send("signup page");
+router.post("/", validate("user"), (_reqest: Request, response: Response) => {
+  response.status(200).send({ message: "Valid user data" });
 });
 
 export default router;

--- a/packages/backend/src/test/user/app.ts
+++ b/packages/backend/src/test/user/app.ts
@@ -1,0 +1,10 @@
+import express from "express";
+import signupRouter from "../../router/user/signup";
+
+const app = express();
+
+app.use(express.json());
+app.use("/signup", signupRouter);
+
+/* exports express app to run on tests */
+export default app;

--- a/packages/backend/src/test/user/signup.test.ts
+++ b/packages/backend/src/test/user/signup.test.ts
@@ -1,0 +1,103 @@
+import request from "supertest";
+import app from "./app";
+
+describe("POST /signup", () => {
+  describe("username edge cases", () => {
+    it("should return 200 for valid user data", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "johndoe",
+        email: "john@example.com",
+        password: "johndoe",
+        confirmPassword: "johndoe",
+      });
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe("Valid user data");
+    });
+
+    it("should return 400 for invalid username, fewer than 5 characters", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "john",
+        email: "john@doe.com",
+        password: "johndoe",
+        confirmPassword: "johndoe",
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error[0].message).toContain(
+        "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
+      );
+    });
+
+    it("should return 400 for invalid username, more than 10 characters", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "john123456789",
+        email: "john@doe.com",
+        password: "johndoe",
+        confirmPassword: "johndoe",
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error[0].message).toContain(
+        "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
+      );
+    });
+
+    it("should return 400 for invalid username, containing special characters except underscore", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "john.",
+        email: "john@doe.com",
+        password: "johndoe",
+        confirmPassword: "johndoe",
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error[0].message).toContain(
+        "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
+      );
+    });
+
+    it("should return 400 for invalid username, containing white space", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "john doe",
+        email: "john@doe.com",
+        password: "johndoe",
+        confirmPassword: "johndoe",
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error[0].message).toContain(
+        "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
+      );
+    });
+  });
+
+  describe("email edge cases", () => {
+    it("should return 400 for invalid email format", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "johndoe",
+        email: "john.doe",
+        password: "johndoe",
+        confirmPassword: "johndoe",
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error[0].message).toContain(
+        'must match format "email"',
+      );
+    });
+  });
+
+  describe("", () => {
+    it("should return 400 if password contains fewer than 5 characters", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "johndoe",
+        email: "johnn@doe.com",
+        password: "john",
+        confirmPassword: "john",
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error[0].message).toBe(
+        "Password must NOT have fewer than 5 characters",
+      );
+    });
+  });
+
+  /* TODO:
+  add test to fail with passwords don't match;
+  blocked: see -- https://stackoverflow.com/questions/79159863/typescript-seems-to-not-fully-support-data-option-for-const-validation */
+});


### PR DESCRIPTION
This pull request adds a `validate` middleware for HTTP request bodies and it is made of four commits;

- The first commit installs the `ajv-formats` and `ajv-errors` packages, which we later use in the `validate` middleware. `ajv-formats` is for JSON Schema format validation for Ajv, and `ajv-errors` is for custom error messages in JSON Schemas for the Ajv validator.
- The second commit implements the `validate` middleware and defines `userSchema` (a representation for signup form data).
- The third commit installs `supertest and @types/supertest` to facilitate HTTP request/response testing.
- The last commit implements a test for the signup form, HTTP request.

**Context:** I have used https://ajv.js.org/ primarily to avoid implementing explicit data validation logic. But there is more than just that, see -- https://ajv.js.org/guide/why-ajv.html.

**Note**: Currently, the `validate` middleware does not validate if the password and confirmPassword fields match.
I have asked for help on Stack Overflow, if you have an answer, please add it there and ping me -- https://stackoverflow.com/questions/79159863/typescript-seems-to-not-fully-support-data-option-for-const-validation.

**Followup**:
- [ ] As a first follow, I shall implement logic to check if the `password` and `confirmPassword` fields' values match.
I have opened a ticket to track it;
https://github.com/lubegasimon/expense-tracker-mobile/issues/5
