### PR TITLE
findUserByEmail query

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,7 +18,7 @@
     "undo:most:recent:seed": "npx sequelize-cli db:seed:undo",
     "start": "npx ts-node ./src/app.ts",
     "fmt": "npx prettier . --write",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "author": "",
   "license": "ISC",

--- a/packages/backend/src/middleware/validation/validateRequestBody.ts
+++ b/packages/backend/src/middleware/validation/validateRequestBody.ts
@@ -34,11 +34,12 @@ const validateRequestBody = (schema: string) => {
     compiled validation function from the ajv instance cache.
   */
   const validate = ajv.getSchema(schema);
-  return (req: Request, res: Response, next: NextFunction) => {
-    const valid = validate && validate(req.body);
-    if (!valid) {
+  return (request: Request, response: Response, next: NextFunction) => {
+    const data = request.body;
+    const valid = validate && validate(data);
+    if (!valid || data.password !== data.confirmPassword) {
       const errors = validate?.errors;
-      res.status(400).json({ error: errors });
+      response.status(400).json({ error: errors });
       return;
     }
     next();

--- a/packages/backend/src/middleware/validation/validateRequestBody.ts
+++ b/packages/backend/src/middleware/validation/validateRequestBody.ts
@@ -19,8 +19,8 @@ ajv.addFormat("username", /^[0-9a-zA-Z_]{5,10}$/);
 */
 ajv.addSchema(userSchema, "user");
 
-/* validate is a middleware to validate request bodies. */
-const validate = (schema: string) => {
+/* validateRequestBody is a middleware to validate request bodies. */
+const validateRequestBody = (schema: string) => {
   /*
     ajv.getSchema returns compiled function that we later use to
     validate the request body.
@@ -45,4 +45,4 @@ const validate = (schema: string) => {
   };
 };
 
-export default validate;
+export default validateRequestBody;

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import validate from "../../middleware/validation/validate";
+import validate from "../../middleware/validation/validateRequestBody";
 const router = Router();
 
 router.post("/", validate("user"), (_reqest: Request, response: Response) => {

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import validate from "../../middleware/validation/validateRequestBody";
 const router = Router();
 
-router.post("/", validate("user"), (_reqest: Request, response: Response) => {
+router.post("/", validate("user"), (_request: Request, response: Response) => {
   response.status(200).send({ message: "Valid user data" });
 });
 

--- a/packages/backend/src/test/user/create.test.ts
+++ b/packages/backend/src/test/user/create.test.ts
@@ -12,8 +12,6 @@ const user = {
 describe("User CRUD operation", () => {
   beforeEach(() => sequelize.truncate());
 
-  afterEach(() => sequelize.truncate());
-
   afterAll(() => sequelize.close());
 
   it("create user", () => {

--- a/packages/backend/src/test/user/find.test.ts
+++ b/packages/backend/src/test/user/find.test.ts
@@ -1,0 +1,33 @@
+import { v4 as uuidv4 } from "uuid";
+import { create } from "../../user/create";
+import { sequelize } from "../../db/db";
+import { findUserByEmail } from "../../user/find";
+
+const user = {
+  id: uuidv4(),
+  username: "johndoe",
+  email: "john@doe.com",
+  password: "johndoe",
+};
+
+describe.only("Find by email", () => {
+  beforeEach(() => sequelize.truncate());
+
+  afterAll(() => sequelize.close());
+
+  it("should return user if email exists", () => {
+    return create(user).then((_result) =>
+      findUserByEmail("john@doe.com").then((result) =>
+        expect(result).toHaveProperty("email", "john@doe.com"),
+      ),
+    );
+  });
+
+  it("should return null if email does not exist or is empty", () => {
+    return create(user).then((_result) =>
+      findUserByEmail("john@doe.net").then((result) => {
+        expect(result).toBeNull();
+      }),
+    );
+  });
+});

--- a/packages/backend/src/test/user/signup.test.ts
+++ b/packages/backend/src/test/user/signup.test.ts
@@ -82,7 +82,7 @@ describe("POST /signup", () => {
     });
   });
 
-  describe("", () => {
+  describe("password edge case", () => {
     it("should return 400 if password contains fewer than 5 characters", async () => {
       const response = await request(app).post("/signup").send({
         username: "johndoe",
@@ -97,7 +97,18 @@ describe("POST /signup", () => {
     });
   });
 
-  /* TODO:
-  add test to fail with passwords don't match;
-  blocked: see -- https://stackoverflow.com/questions/79159863/typescript-seems-to-not-fully-support-data-option-for-const-validation */
+  /* TODO: Could be improved, but blocked:
+   see -- https://stackoverflow.com/questions/79159863/typescript-seems-to-not-fully-support-data-option-for-const-validation */
+  describe("cross password edge case", () => {
+    it("should return 400 if passwords do not match", async () => {
+      const response = await request(app).post("/signup").send({
+        username: "johndoe",
+        email: "johnn@doe.com",
+        password: "johndoe",
+        confirmPassword: "johndo",
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error[0].message).toBe("Passwords do not match");
+    });
+  });
 });

--- a/packages/backend/src/user/find.ts
+++ b/packages/backend/src/user/find.ts
@@ -1,0 +1,8 @@
+import { UserModel } from "./model";
+
+export const findUserByEmail = (email: string) => {
+  return UserModel.findOne({
+    where: { email },
+    attributes: { exclude: ["createdAt", "updatedAt"] },
+  });
+};


### PR DESCRIPTION
This pull request solves Task 3 of https://github.com/lubegasimon/expense-tracker-mobile/issues/2 and depends on https://github.com/lubegasimon/expense-tracker-mobile/pull/10. It consists of three commits;
- The first commit implements the `findUserByEmail` query.
- The second commit adds a `--runInBand` flag to `test` to force jest to run tests sequentially. This is a hack to avoid inconsistent test results due to concurrently running `find.test.ts` and `create.test.ts`. However, it is at the expense that when a test in a sequence fails, all others next in the sequence are flagged as failures.
If you may, feel free to ensure consistency without using the `--runInBand` flag. Otherwise, I shall remove it in one of the next commits.
- The third commit is a test case of the `findUserByEmail` query.