### PR TITLE
Associate verification code with candidate's email

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,6 +17,7 @@
     "seed": "npx sequelize-cli db:seed:all",
     "undo:most:recent:seed": "npx sequelize-cli db:seed:undo",
     "start": "npx ts-node ./src/app.ts",
+    "redis": "redis-server",
     "fmt": "npx prettier . --write",
     "test": "jest --runInBand"
   },

--- a/packages/backend/src/middleware/session.ts
+++ b/packages/backend/src/middleware/session.ts
@@ -2,15 +2,16 @@ import RedisStore from "connect-redis";
 import { createClient } from "redis";
 import session from "express-session";
 import { v4 as uuidv4 } from "uuid";
-
 import { secret } from "../config";
+import { redisError } from "../router/user/error";
 
-let redisClient = createClient();
-redisClient.connect().catch(console.error);
+export const redisClient = createClient();
 
-const redisStore = new RedisStore({
+redisClient.connect().catch((error) => redisError(error));
+
+export const redisStore = new RedisStore({
   client: redisClient,
-  prefix: "myapp:",
+  prefix: "expense-tracker:",
 });
 
 export const sessionManager = session({

--- a/packages/backend/src/router/user/error.ts
+++ b/packages/backend/src/router/user/error.ts
@@ -1,6 +1,4 @@
-export const redisError = (error: string) => {
-  console.error(
-    `An error '${error}' occured while saving candidate data in Redis`,
-  );
+export const redisError = (error: any) => {
+  console.error(error);
   throw new Error("Internal server error");
 };

--- a/packages/backend/src/router/user/error.ts
+++ b/packages/backend/src/router/user/error.ts
@@ -1,0 +1,6 @@
+export const redisError = (error: string) => {
+  console.error(
+    `An error '${error}' occured while saving candidate data in Redis`,
+  );
+  throw new Error("Internal server error");
+};

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,9 +1,39 @@
 import { Router, Request, Response } from "express";
+import RedisStore from "connect-redis";
 import validate from "../../middleware/validation/validateRequestBody";
+import { redisClient, redisStore } from "../../middleware/session";
+import { redisError } from "./error";
+
 const router = Router();
 
-router.post("/", validate("user"), (_request: Request, response: Response) => {
-  response.status(200).send({ message: "Valid user data" });
-});
+async function saveCandidateData(
+  username: string,
+  email: string,
+  password: string,
+  redisStore: RedisStore,
+) {
+  const candidateData = JSON.stringify({ username, email, password });
+  await redisStore.client
+    .set(`signup:${email}`, candidateData, 86400)
+    .catch((error) => redisError(error));
+}
+
+router.post(
+  "/",
+  validate("user"),
+  async (request: Request, response: Response) => {
+    const data = request.body;
+    const { username, email, password } = data;
+
+    await saveCandidateData(username, email, password, redisStore);
+    const savedCandidateData = await redisClient
+      .get(`signup:${data.email}`)
+      .catch((error) => redisError(error));
+
+    response
+      .status(200)
+      .send({ message: "Valid user data", savedCandidateData });
+  },
+);
 
 export default router;

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,10 +1,24 @@
 import { Router, Request, Response } from "express";
 import RedisStore from "connect-redis";
+import { randomBytes } from "crypto";
 import validate from "../../middleware/validation/validateRequestBody";
 import { redisClient, redisStore } from "../../middleware/session";
 import { redisError } from "./error";
 
 const router = Router();
+
+const token = () => {
+  randomBytes(10, (error, buffer) => {
+    if (error) throw error;
+    buffer.toString("hex");
+  });
+};
+
+async function associateTokenToEmail(email: string) {
+  await redisStore.client
+    .set(`verification:${token}`, email, 300)
+    .catch((error) => redisError(error));
+}
 
 async function saveCandidateData(
   username: string,
@@ -26,13 +40,19 @@ router.post(
     const { username, email, password } = data;
 
     await saveCandidateData(username, email, password, redisStore);
+    await associateTokenToEmail(data.email);
+
     const savedCandidateData = await redisClient
       .get(`signup:${data.email}`)
       .catch((error) => redisError(error));
 
+    const savedToken = await redisClient
+      .get(`verification:${token}`)
+      .catch((error) => redisError(error));
+
     response
       .status(200)
-      .send({ message: "Valid user data", savedCandidateData });
+      .send({ message: "Valid user data", savedCandidateData, savedToken });
   },
 );
 

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -1,0 +1,23 @@
+import request from "supertest";
+import app from "../app";
+import { redisClient } from "../../../middleware/session";
+import { redisError } from "../../../router/user/error";
+
+describe("Check if candidate data is saved in Redis storage", () => {
+  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
+  afterEach(() =>
+    redisClient.del("signup*").catch((error) => redisError(error)),
+  );
+
+  it("should return saved candidate's data ", async () => {
+    const response = await request(app).post("/signup").send({
+      username: "johndoe",
+      email: "johnn@doe.com",
+      password: "johndoe",
+      confirmPassword: "johndoe",
+    });
+    expect(response.body.savedCandidateData).toBe(
+      '{"username":"johndoe","email":"johnn@doe.com","password":"johndoe"}',
+    );
+  });
+});

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -10,7 +10,7 @@ const data = {
   confirmPassword: "johndoe",
 };
 
-describe("Check if candidate data and token are saved in Redis", () => {
+describe("Check if candidate data and verification code are saved in Redis", () => {
   afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
   afterEach(() =>
     redisClient.del("signup*").catch((error) => redisError(error)),
@@ -23,8 +23,8 @@ describe("Check if candidate data and token are saved in Redis", () => {
     );
   });
 
-  it("should return saved token, associated to candidate's email", async () => {
+  it("should return saved verification code, associated to candidate's email", async () => {
     const response = await request(app).post("/signup").send(data);
-    expect(response.body.savedToken).toBe("johnn@doe.com");
+    expect(response.body.savedVerificationCode).toBe("johnn@doe.com");
   });
 });

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -3,21 +3,28 @@ import app from "../app";
 import { redisClient } from "../../../middleware/session";
 import { redisError } from "../../../router/user/error";
 
-describe("Check if candidate data is saved in Redis storage", () => {
+const data = {
+  username: "johndoe",
+  email: "johnn@doe.com",
+  password: "johndoe",
+  confirmPassword: "johndoe",
+};
+
+describe("Check if candidate data and token are saved in Redis", () => {
   afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
   afterEach(() =>
     redisClient.del("signup*").catch((error) => redisError(error)),
   );
 
   it("should return saved candidate's data ", async () => {
-    const response = await request(app).post("/signup").send({
-      username: "johndoe",
-      email: "johnn@doe.com",
-      password: "johndoe",
-      confirmPassword: "johndoe",
-    });
+    const response = await request(app).post("/signup").send(data);
     expect(response.body.savedCandidateData).toBe(
       '{"username":"johndoe","email":"johnn@doe.com","password":"johndoe"}',
     );
+  });
+
+  it("should return saved token, associated to candidate's email", async () => {
+    const response = await request(app).post("/signup").send(data);
+    expect(response.body.savedToken).toBe("johnn@doe.com");
   });
 });


### PR DESCRIPTION
This pull request solves Tasks 6 and 7 of https://github.com/lubegasimon/expense-tracker-mobile/issues/2 and depends on https://github.com/lubegasimon/expense-tracker-mobile/pull/14. It consists of ~three~ four commits;
- The first commit ensures detailed Redis error logging (edits: `error.ts` which was introduced in https://github.com/lubegasimon/expense-tracker-mobile/pull/14)
- The second commit generates a unique token and associates it with the candidate's email
- The third commit is a test case for the implementation.

**New:**
- The fourth commit generates random code instead of a random string. The code is to be sent to the candidate's email. It's to act as the verification code.