### PR TITLE
Setup and configure sendgrid to send email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 node_modules
 .env
+.env.test
 notes
 dump.rdb

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,5 +1,8 @@
 # used to sign session ID.
-SECRET="secret"
+SECRET=secret
 
 # DATABASE_URI=postgresql://username:password@host:port/dtabase_name
 DATABASE_URI=postgresql://ocamler@localhost/expense_tracker_test
+
+SENDGRID_API_KEY=SG.lqfenkjfnd90io.034nfacnqlwfbcvljfef01943
+EXPENSE_TRACKER_EMAIL=youremail@example.com

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@sendgrid/mail": "^8.1.4",
         "@types/bcrypt": "^5.0.2",
         "@types/cookie-parser": "^1.4.7",
         "@types/supertest": "^6.0.2",
@@ -1286,6 +1287,44 @@
         "@redis/client": "^1.0.0"
       }
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.4.tgz",
+      "integrity": "sha512-VxZoQ82MpxmjSXLR3ZAE2OWxvQIW2k2G24UeRPr/SYX8HqWLV/8UBN15T2WmjjnEb5XSmFImTJOKDzzSeKr9YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.4.tgz",
+      "integrity": "sha512-MUpIZykD9ARie8LElYCqbcBhGGMaA/E6I7fEcG7Hc2An26QJyLtwOaKQ3taGp8xO8BICPJrSKuYV4bDeAJKFGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.4",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1893,6 +1932,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2602,7 +2652,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3252,6 +3301,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/foreground-child": {
@@ -5651,6 +5720,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,6 +17,7 @@
     "seed": "npx sequelize-cli db:seed:all",
     "undo:most:recent:seed": "npx sequelize-cli db:seed:undo",
     "start": "npx ts-node ./src/app.ts",
+    "redis": "redis-server",
     "fmt": "npx prettier . --write",
     "test": "jest --runInBand"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,6 +36,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "@sendgrid/mail": "^8.1.4",
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.7",
     "@types/supertest": "^6.0.2",

--- a/packages/backend/src/middleware/session.ts
+++ b/packages/backend/src/middleware/session.ts
@@ -2,15 +2,16 @@ import RedisStore from "connect-redis";
 import { createClient } from "redis";
 import session from "express-session";
 import { v4 as uuidv4 } from "uuid";
-
 import { secret } from "../config";
+import { redisError } from "../router/user/error";
 
-let redisClient = createClient();
-redisClient.connect().catch(console.error);
+export const redisClient = createClient();
 
-const redisStore = new RedisStore({
+redisClient.connect().catch((error) => redisError(error));
+
+export const redisStore = new RedisStore({
   client: redisClient,
-  prefix: "myapp:",
+  prefix: "expense-tracker:",
 });
 
 export const sessionManager = session({

--- a/packages/backend/src/router/user/error.ts
+++ b/packages/backend/src/router/user/error.ts
@@ -1,6 +1,4 @@
-export const redisError = (error: string) => {
-  console.error(
-    `An error '${error}' occured while saving candidate data in Redis`,
-  );
+export const redisError = (error: any) => {
+  console.error(error);
   throw new Error("Internal server error");
 };

--- a/packages/backend/src/router/user/error.ts
+++ b/packages/backend/src/router/user/error.ts
@@ -1,0 +1,6 @@
+export const redisError = (error: string) => {
+  console.error(
+    `An error '${error}' occured while saving candidate data in Redis`,
+  );
+  throw new Error("Internal server error");
+};

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,9 +1,39 @@
 import { Router, Request, Response } from "express";
+import RedisStore from "connect-redis";
 import validate from "../../middleware/validation/validateRequestBody";
+import { redisClient, redisStore } from "../../middleware/session";
+import { redisError } from "./error";
+
 const router = Router();
 
-router.post("/", validate("user"), (_request: Request, response: Response) => {
-  response.status(200).send({ message: "Valid user data" });
-});
+async function saveCandidateData(
+  username: string,
+  email: string,
+  password: string,
+  redisStore: RedisStore,
+) {
+  const candidateData = JSON.stringify({ username, email, password });
+  await redisStore.client
+    .set(`signup:${email}`, candidateData, 86400)
+    .catch((error) => redisError(error));
+}
+
+router.post(
+  "/",
+  validate("user"),
+  async (request: Request, response: Response) => {
+    const data = request.body;
+    const { username, email, password } = data;
+
+    await saveCandidateData(username, email, password, redisStore);
+    const savedCandidateData = await redisClient
+      .get(`signup:${data.email}`)
+      .catch((error) => redisError(error));
+
+    response
+      .status(200)
+      .send({ message: "Valid user data", savedCandidateData });
+  },
+);
 
 export default router;

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,10 +1,24 @@
 import { Router, Request, Response } from "express";
 import RedisStore from "connect-redis";
+import { randomBytes } from "crypto";
 import validate from "../../middleware/validation/validateRequestBody";
 import { redisClient, redisStore } from "../../middleware/session";
 import { redisError } from "./error";
 
 const router = Router();
+
+const token = () => {
+  randomBytes(10, (error, buffer) => {
+    if (error) throw error;
+    buffer.toString("hex");
+  });
+};
+
+async function associateTokenToEmail(email: string) {
+  await redisStore.client
+    .set(`verification:${token}`, email, 300)
+    .catch((error) => redisError(error));
+}
 
 async function saveCandidateData(
   username: string,
@@ -26,13 +40,19 @@ router.post(
     const { username, email, password } = data;
 
     await saveCandidateData(username, email, password, redisStore);
+    await associateTokenToEmail(data.email);
+
     const savedCandidateData = await redisClient
       .get(`signup:${data.email}`)
       .catch((error) => redisError(error));
 
+    const savedToken = await redisClient
+      .get(`verification:${token}`)
+      .catch((error) => redisError(error));
+
     response
       .status(200)
-      .send({ message: "Valid user data", savedCandidateData });
+      .send({ message: "Valid user data", savedCandidateData, savedToken });
   },
 );
 

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -27,4 +27,15 @@ describe("Check if candidate data and verification code are saved in Redis", () 
     const response = await request(app).post("/signup").send(data);
     expect(response.body.savedVerificationCode).toBe("johnn@doe.com");
   });
+
+  // TODO: Use stubs because an email is sent whenever this test runs.
+  it("should send email to candidate's email", async () => {
+    const response = await request(app).post("/signup").send({
+      username: "johndoe",
+      email: "lubegasimon73@gmail.com",
+      password: "johndoe",
+      confirmPassword: "johndoe",
+    });
+    expect(response.body.sendEmailStatus).toBe("Email sent");
+  });
 });

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -1,0 +1,23 @@
+import request from "supertest";
+import app from "../app";
+import { redisClient } from "../../../middleware/session";
+import { redisError } from "../../../router/user/error";
+
+describe("Check if candidate data is saved in Redis storage", () => {
+  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
+  afterEach(() =>
+    redisClient.del("signup*").catch((error) => redisError(error)),
+  );
+
+  it("should return saved candidate's data ", async () => {
+    const response = await request(app).post("/signup").send({
+      username: "johndoe",
+      email: "johnn@doe.com",
+      password: "johndoe",
+      confirmPassword: "johndoe",
+    });
+    expect(response.body.savedCandidateData).toBe(
+      '{"username":"johndoe","email":"johnn@doe.com","password":"johndoe"}',
+    );
+  });
+});

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -10,7 +10,7 @@ const data = {
   confirmPassword: "johndoe",
 };
 
-describe("Check if candidate data and token are saved in Redis", () => {
+describe("Check if candidate data and verification code are saved in Redis", () => {
   afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
   afterEach(() =>
     redisClient.del("signup*").catch((error) => redisError(error)),
@@ -23,8 +23,8 @@ describe("Check if candidate data and token are saved in Redis", () => {
     );
   });
 
-  it("should return saved token, associated to candidate's email", async () => {
+  it("should return saved verification code, associated to candidate's email", async () => {
     const response = await request(app).post("/signup").send(data);
-    expect(response.body.savedToken).toBe("johnn@doe.com");
+    expect(response.body.savedVerificationCode).toBe("johnn@doe.com");
   });
 });

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -3,21 +3,28 @@ import app from "../app";
 import { redisClient } from "../../../middleware/session";
 import { redisError } from "../../../router/user/error";
 
-describe("Check if candidate data is saved in Redis storage", () => {
+const data = {
+  username: "johndoe",
+  email: "johnn@doe.com",
+  password: "johndoe",
+  confirmPassword: "johndoe",
+};
+
+describe("Check if candidate data and token are saved in Redis", () => {
   afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
   afterEach(() =>
     redisClient.del("signup*").catch((error) => redisError(error)),
   );
 
   it("should return saved candidate's data ", async () => {
-    const response = await request(app).post("/signup").send({
-      username: "johndoe",
-      email: "johnn@doe.com",
-      password: "johndoe",
-      confirmPassword: "johndoe",
-    });
+    const response = await request(app).post("/signup").send(data);
     expect(response.body.savedCandidateData).toBe(
       '{"username":"johndoe","email":"johnn@doe.com","password":"johndoe"}',
     );
+  });
+
+  it("should return saved token, associated to candidate's email", async () => {
+    const response = await request(app).post("/signup").send(data);
+    expect(response.body.savedToken).toBe("johnn@doe.com");
   });
 });


### PR DESCRIPTION
This pull request solves tasks 7 and 8 of https://github.com/lubegasimon/expense-tracker-mobile/issues/2 and depends on https://github.com/lubegasimon/expense-tracker-mobile/pull/15. It consists of four commits;
- The first commit installs `sendgrid/mail` client, adds`.env.test` file to `.gitignore`, and some variables to `.env.example`.
- The second commit sets up and configures SendGrid to send a verification link to the candidate's email.
- The third commit is a test to verify that the email was sent.
- The fourth commit ensures that the verification code is generated before sending it to the candidate's email

**Note:** This pull request is an alpha implementation. Things to improve;
- [ ] Track email status using Event webhooks
- [ ] Use stubs or mocks to test if the verification link is sent to the candidate's email.
https://github.com/lubegasimon/expense-tracker-mobile/issues/17 has been created to keep track of the above stretch tasks.
