### PR TITLE
Add verify-code endpoint and verifyCode route handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 node_modules
 .env
+.env.test
 notes
 dump.rdb

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,5 +1,8 @@
 # used to sign session ID.
-SECRET="secret"
+SECRET=secret
 
 # DATABASE_URI=postgresql://username:password@host:port/dtabase_name
 DATABASE_URI=postgresql://ocamler@localhost/expense_tracker_test
+
+SENDGRID_API_KEY=SG.lqfenkjfnd90io.034nfacnqlwfbcvljfef01943
+EXPENSE_TRACKER_EMAIL=youremail@example.com

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@sendgrid/mail": "^8.1.4",
         "@types/bcrypt": "^5.0.2",
         "@types/cookie-parser": "^1.4.7",
         "@types/supertest": "^6.0.2",
@@ -1286,6 +1287,44 @@
         "@redis/client": "^1.0.0"
       }
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.4.tgz",
+      "integrity": "sha512-VxZoQ82MpxmjSXLR3ZAE2OWxvQIW2k2G24UeRPr/SYX8HqWLV/8UBN15T2WmjjnEb5XSmFImTJOKDzzSeKr9YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.4.tgz",
+      "integrity": "sha512-MUpIZykD9ARie8LElYCqbcBhGGMaA/E6I7fEcG7Hc2An26QJyLtwOaKQ3taGp8xO8BICPJrSKuYV4bDeAJKFGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.4",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1893,6 +1932,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2602,7 +2652,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3252,6 +3301,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/foreground-child": {
@@ -5651,6 +5720,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,6 +17,7 @@
     "seed": "npx sequelize-cli db:seed:all",
     "undo:most:recent:seed": "npx sequelize-cli db:seed:undo",
     "start": "npx ts-node ./src/app.ts",
+    "redis": "redis-server",
     "fmt": "npx prettier . --write",
     "test": "jest --runInBand"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,6 +36,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "@sendgrid/mail": "^8.1.4",
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.7",
     "@types/supertest": "^6.0.2",

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -3,6 +3,7 @@ import cookieParser from "cookie-parser";
 import app from "./server";
 import indexRouter from "./router/user/index";
 import signupRouter from "./router/user/signup";
+import verifyCode from "./router/user/verifyCode";
 import { sessionManager } from "./middleware/session";
 import { logger } from "./middleware/logger";
 
@@ -14,6 +15,7 @@ app.use(logger);
 
 app.use("/", indexRouter);
 app.use("/signup", signupRouter);
+app.use("/signup/verify-code", verifyCode);
 
 app.listen(port, () => {
   console.log(`App listening on port ${port} \n`);

--- a/packages/backend/src/middleware/session.ts
+++ b/packages/backend/src/middleware/session.ts
@@ -2,15 +2,16 @@ import RedisStore from "connect-redis";
 import { createClient } from "redis";
 import session from "express-session";
 import { v4 as uuidv4 } from "uuid";
-
 import { secret } from "../config";
+import { redisError } from "../router/user/error";
 
-let redisClient = createClient();
-redisClient.connect().catch(console.error);
+export const redisClient = createClient();
 
-const redisStore = new RedisStore({
+redisClient.connect().catch((error) => redisError(error));
+
+export const redisStore = new RedisStore({
   client: redisClient,
-  prefix: "myapp:",
+  prefix: "expense-tracker:",
 });
 
 export const sessionManager = session({

--- a/packages/backend/src/middleware/validation/validateRequestBody.ts
+++ b/packages/backend/src/middleware/validation/validateRequestBody.ts
@@ -3,7 +3,7 @@ import { Ajv } from "ajv";
 import addFormats from "ajv-formats";
 import addErrors from "ajv-errors";
 import userSchema from "./schemas/userSchema";
-import { findUserByEmail } from "../../user/find";
+import findUserByEmail from "../../user/find";
 
 const ajv = new Ajv({ allErrors: true, $data: true });
 addFormats(ajv);

--- a/packages/backend/src/router/user/error.ts
+++ b/packages/backend/src/router/user/error.ts
@@ -1,6 +1,4 @@
-export const redisError = (error: string) => {
-  console.error(
-    `An error '${error}' occured while saving candidate data in Redis`,
-  );
+export const redisError = (error: any) => {
+  console.error(error);
   throw new Error("Internal server error");
 };

--- a/packages/backend/src/router/user/error.ts
+++ b/packages/backend/src/router/user/error.ts
@@ -1,0 +1,6 @@
+export const redisError = (error: string) => {
+  console.error(
+    `An error '${error}' occured while saving candidate data in Redis`,
+  );
+  throw new Error("Internal server error");
+};

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,9 +1,39 @@
 import { Router, Request, Response } from "express";
+import RedisStore from "connect-redis";
 import validate from "../../middleware/validation/validateRequestBody";
+import { redisClient, redisStore } from "../../middleware/session";
+import { redisError } from "./error";
+
 const router = Router();
 
-router.post("/", validate("user"), (_request: Request, response: Response) => {
-  response.status(200).send({ message: "Valid user data" });
-});
+async function saveCandidateData(
+  username: string,
+  email: string,
+  password: string,
+  redisStore: RedisStore,
+) {
+  const candidateData = JSON.stringify({ username, email, password });
+  await redisStore.client
+    .set(`signup:${email}`, candidateData, 86400)
+    .catch((error) => redisError(error));
+}
+
+router.post(
+  "/",
+  validate("user"),
+  async (request: Request, response: Response) => {
+    const data = request.body;
+    const { username, email, password } = data;
+
+    await saveCandidateData(username, email, password, redisStore);
+    const savedCandidateData = await redisClient
+      .get(`signup:${data.email}`)
+      .catch((error) => redisError(error));
+
+    response
+      .status(200)
+      .send({ message: "Valid user data", savedCandidateData });
+  },
+);
 
 export default router;

--- a/packages/backend/src/router/user/signup.ts
+++ b/packages/backend/src/router/user/signup.ts
@@ -1,10 +1,24 @@
 import { Router, Request, Response } from "express";
 import RedisStore from "connect-redis";
+import { randomBytes } from "crypto";
 import validate from "../../middleware/validation/validateRequestBody";
 import { redisClient, redisStore } from "../../middleware/session";
 import { redisError } from "./error";
 
 const router = Router();
+
+const token = () => {
+  randomBytes(10, (error, buffer) => {
+    if (error) throw error;
+    buffer.toString("hex");
+  });
+};
+
+async function associateTokenToEmail(email: string) {
+  await redisStore.client
+    .set(`verification:${token}`, email, 300)
+    .catch((error) => redisError(error));
+}
 
 async function saveCandidateData(
   username: string,
@@ -26,13 +40,19 @@ router.post(
     const { username, email, password } = data;
 
     await saveCandidateData(username, email, password, redisStore);
+    await associateTokenToEmail(data.email);
+
     const savedCandidateData = await redisClient
       .get(`signup:${data.email}`)
       .catch((error) => redisError(error));
 
+    const savedToken = await redisClient
+      .get(`verification:${token}`)
+      .catch((error) => redisError(error));
+
     response
       .status(200)
-      .send({ message: "Valid user data", savedCandidateData });
+      .send({ message: "Valid user data", savedCandidateData, savedToken });
   },
 );
 

--- a/packages/backend/src/router/user/verifyCode.ts
+++ b/packages/backend/src/router/user/verifyCode.ts
@@ -1,0 +1,9 @@
+import { Request, Response, Router } from "express";
+const router = Router();
+
+router.post("/", async (request: Request, response: Response) => {
+  const data = await request.body;
+  response.status(200).json({ message: "Valid code", code: data.code });
+});
+
+export default router;

--- a/packages/backend/src/router/user/verifyCode.ts
+++ b/packages/backend/src/router/user/verifyCode.ts
@@ -1,9 +1,62 @@
 import { Request, Response, Router } from "express";
+import { redisStore } from "../../middleware/session";
+import { redisError } from "./error";
+import create from "../../user/create";
+import { UserAttrs } from "../../user/model";
+import findUserByEmail from "../../user/find";
+
 const router = Router();
 
-router.post("/", async (request: Request, response: Response) => {
-  const data = await request.body;
-  response.status(200).json({ message: "Valid code", code: data.code });
-});
+function createUser(user: UserAttrs, response: Response) {
+  findUserByEmail(user.email)
+    .then((rows) => {
+      if (rows) response.status(409).json({ error: "Email already exists" });
+      else
+        create({
+          username: user.username,
+          email: user.email,
+          password: user.password,
+        })
+          .then((user) =>
+            response.status(201).json({
+              message: `Account successfully created, welcome ${user.username}!`,
+            }),
+          )
+          .catch((error) => {
+            // TODO: How can a user recover from this error?
+            console.error(error);
+            response.status(500).send({ error: "Internal server error" });
+          });
+    })
+    .catch((error) => console.error(error));
+}
+
+function saveCandidateByEmail(email: string, response: Response) {
+  redisStore.client
+    .get(`signup:${email}`)
+    .then((data) => {
+      if (data) {
+        let { username, email, password } = JSON.parse(data);
+        createUser({ username, email, password }, response);
+      } else
+        response.status(401).json({
+          error: "Your session has expired. Please start new signup process",
+        });
+    })
+    .catch((error) => redisError(error));
+}
+
+function verifyCode(request: Request, response: Response) {
+  const data = request.body;
+  redisStore.client
+    .get(`verification:${data.code}`)
+    .then((result) => {
+      if (!result) response.status(400).json({ error: "Invalid code" });
+      else saveCandidateByEmail(result, response);
+    })
+    .catch((error) => redisError(error));
+}
+
+router.post("/", verifyCode);
 
 export default router;

--- a/packages/backend/src/test/redis.test.ts
+++ b/packages/backend/src/test/redis.test.ts
@@ -8,7 +8,6 @@ redisClient.connect().catch((error) => redisError(error));
 
 const redisStore = new RedisStore({
   client: redisClient,
-  prefix: "expense-tracker:",
 });
 
 const user = {
@@ -18,12 +17,17 @@ const user = {
 };
 
 describe("Redis operations", () => {
+  afterAll(() =>
+    redisStore.client
+      .del([`signup:${user.email}`, `verification:${user.email}`])
+      .catch((error) => redisError(error)),
+  );
   afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
 
-  it("should add data in Redis", async () => {
+  it("should save user data in Redis", async () => {
     const data = JSON.stringify(user);
     const response = await redisStore.client
-      .set(`signup:${user.email}`, data, 1)
+      .set(`signup:${user.email}`, data)
       .catch((error) => redisError(error));
 
     expect(response).toBe("OK");
@@ -42,7 +46,6 @@ describe("Redis operations", () => {
       .get(`signup:${user.email}`)
       .catch((error) => redisError(error));
 
-    console.log("Response", response);
     expect(response).toBe(
       '{"username":"johndoe","email":"john@doe.com","password":"johndoe"}',
     );

--- a/packages/backend/src/test/redis.test.ts
+++ b/packages/backend/src/test/redis.test.ts
@@ -1,0 +1,68 @@
+import RedisStore from "connect-redis";
+import { createClient } from "redis";
+import { redisError } from "../router/user/error";
+
+const redisClient = createClient();
+
+redisClient.connect().catch((error) => redisError(error));
+
+const redisStore = new RedisStore({
+  client: redisClient,
+  prefix: "expense-tracker:",
+});
+
+const user = {
+  username: "johndoe",
+  email: "john@doe.com",
+  password: "johndoe",
+};
+
+describe("Redis operations", () => {
+  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
+
+  it("should add data in Redis", async () => {
+    const data = JSON.stringify(user);
+    const response = await redisStore.client
+      .set(`signup:${user.email}`, data, 1)
+      .catch((error) => redisError(error));
+
+    expect(response).toBe("OK");
+  });
+
+  it("should return null for invalid redis key", async () => {
+    const response = await redisStore.client
+      .get(`signup:*`)
+      .catch((error) => redisError(error));
+
+    expect(response).toBe(null);
+  });
+
+  it("should return data associated to redis key", async () => {
+    const response = await redisStore.client
+      .get(`signup:${user.email}`)
+      .catch((error) => redisError(error));
+
+    console.log("Response", response);
+    expect(response).toBe(
+      '{"username":"johndoe","email":"john@doe.com","password":"johndoe"}',
+    );
+  });
+
+  it("should set verification:<email> key and expiry in Redis", async () => {
+    const data = JSON.stringify(user);
+    const response = await redisStore.client
+      .set(`verification:${user.email}`, data)
+      .then((_) => redisStore.client.expire(`verification:${user.email}`, -1))
+      .catch((error) => redisError(error));
+
+    expect(response).toBe(true);
+  });
+
+  it("should fail to retrieve data when key expires", async () => {
+    const response = await redisStore.client
+      .get(`verification:${user.email}`)
+      .catch((error) => redisError(error));
+
+    expect(response).toBe(null);
+  });
+});

--- a/packages/backend/src/test/redis.test.ts
+++ b/packages/backend/src/test/redis.test.ts
@@ -48,6 +48,23 @@ describe("Redis operations", () => {
     );
   });
 
+  it("should set verification:<email> key in Redis", async () => {
+    const data = JSON.stringify(user);
+    const response = await redisStore.client
+      .set(`verification:${user.email}`, user.email)
+      .catch((error) => redisError(error));
+
+    expect(response).toBe("OK");
+  });
+
+  it("should retrieve email associated to verification:<email> key in Redis", async () => {
+    const response = await redisStore.client
+      .get(`verification:${user.email}`)
+      .catch((error) => redisError(error));
+
+    expect(response).toBe("john@doe.com");
+  });
+
   it("should set verification:<email> key and expiry in Redis", async () => {
     const data = JSON.stringify(user);
     const response = await redisStore.client

--- a/packages/backend/src/test/user/app.ts
+++ b/packages/backend/src/test/user/app.ts
@@ -1,10 +1,12 @@
 import express from "express";
 import signupRouter from "../../router/user/signup";
+import verifyCodeRouter from "../../router/user/verifyCode";
 
 const app = express();
 
 app.use(express.json());
 app.use("/signup", signupRouter);
+app.use("/signup/verify-code", verifyCodeRouter);
 
 /* exports express app to run on tests */
 export default app;

--- a/packages/backend/src/test/user/create.test.ts
+++ b/packages/backend/src/test/user/create.test.ts
@@ -1,4 +1,4 @@
-import { create } from "../../user/create";
+import create from "../../user/create";
 import { sequelize } from "../../db/db";
 import { v4 as uuidv4 } from "uuid";
 

--- a/packages/backend/src/test/user/find.test.ts
+++ b/packages/backend/src/test/user/find.test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
-import { create } from "../../user/create";
+import create from "../../user/create";
 import { sequelize } from "../../db/db";
-import { findUserByEmail } from "../../user/find";
+import findUserByEmail from "../../user/find";
 
 const user = {
   id: uuidv4(),

--- a/packages/backend/src/test/user/signup/email.test.ts
+++ b/packages/backend/src/test/user/signup/email.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import app from "../app";
-import { create } from "../../../user/create";
+import create from "../../../user/create";
 import { sequelize } from "../../../db/db";
 
 describe("email edge cases", () => {

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -27,4 +27,15 @@ describe("Check if candidate data and verification code are saved in Redis", () 
     const response = await request(app).post("/signup").send(data);
     expect(response.body.savedVerificationCode).toBe("johnn@doe.com");
   });
+
+  // TODO: Use stubs because an email is sent whenever this test runs.
+  it("should send email to candidate's email", async () => {
+    const response = await request(app).post("/signup").send({
+      username: "johndoe",
+      email: "lubegasimon73@gmail.com",
+      password: "johndoe",
+      confirmPassword: "johndoe",
+    });
+    expect(response.body.sendEmailStatus).toBe("Email sent");
+  });
 });

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -1,0 +1,23 @@
+import request from "supertest";
+import app from "../app";
+import { redisClient } from "../../../middleware/session";
+import { redisError } from "../../../router/user/error";
+
+describe("Check if candidate data is saved in Redis storage", () => {
+  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
+  afterEach(() =>
+    redisClient.del("signup*").catch((error) => redisError(error)),
+  );
+
+  it("should return saved candidate's data ", async () => {
+    const response = await request(app).post("/signup").send({
+      username: "johndoe",
+      email: "johnn@doe.com",
+      password: "johndoe",
+      confirmPassword: "johndoe",
+    });
+    expect(response.body.savedCandidateData).toBe(
+      '{"username":"johndoe","email":"johnn@doe.com","password":"johndoe"}',
+    );
+  });
+});

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -10,7 +10,7 @@ const data = {
   confirmPassword: "johndoe",
 };
 
-describe("Check if candidate data and token are saved in Redis", () => {
+describe("Check if candidate data and verification code are saved in Redis", () => {
   afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
   afterEach(() =>
     redisClient.del("signup*").catch((error) => redisError(error)),
@@ -23,8 +23,8 @@ describe("Check if candidate data and token are saved in Redis", () => {
     );
   });
 
-  it("should return saved token, associated to candidate's email", async () => {
+  it("should return saved verification code, associated to candidate's email", async () => {
     const response = await request(app).post("/signup").send(data);
-    expect(response.body.savedToken).toBe("johnn@doe.com");
+    expect(response.body.savedVerificationCode).toBe("johnn@doe.com");
   });
 });

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -3,21 +3,28 @@ import app from "../app";
 import { redisClient } from "../../../middleware/session";
 import { redisError } from "../../../router/user/error";
 
-describe("Check if candidate data is saved in Redis storage", () => {
+const data = {
+  username: "johndoe",
+  email: "johnn@doe.com",
+  password: "johndoe",
+  confirmPassword: "johndoe",
+};
+
+describe("Check if candidate data and token are saved in Redis", () => {
   afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
   afterEach(() =>
     redisClient.del("signup*").catch((error) => redisError(error)),
   );
 
   it("should return saved candidate's data ", async () => {
-    const response = await request(app).post("/signup").send({
-      username: "johndoe",
-      email: "johnn@doe.com",
-      password: "johndoe",
-      confirmPassword: "johndoe",
-    });
+    const response = await request(app).post("/signup").send(data);
     expect(response.body.savedCandidateData).toBe(
       '{"username":"johndoe","email":"johnn@doe.com","password":"johndoe"}',
     );
+  });
+
+  it("should return saved token, associated to candidate's email", async () => {
+    const response = await request(app).post("/signup").send(data);
+    expect(response.body.savedToken).toBe("johnn@doe.com");
   });
 });

--- a/packages/backend/src/test/user/signup/verifyCode.test.ts
+++ b/packages/backend/src/test/user/signup/verifyCode.test.ts
@@ -1,0 +1,14 @@
+import request from "supertest";
+import app from "../app";
+
+describe("Request to verifyCode endpoint", () => {
+  it("should post to verifyCode endpoint", async () => {
+    const response = await request(app).post("/signup/verify-code").send({
+      code: 1234,
+    });
+    console.log("Status code", response.statusCode);
+    console.log("Error message", response.error);
+    console.log("Response body", response.body);
+    expect(response.body.message).toBe("Valid code");
+  });
+});

--- a/packages/backend/src/test/user/signup/verifyCode.test.ts
+++ b/packages/backend/src/test/user/signup/verifyCode.test.ts
@@ -1,14 +1,125 @@
 import request from "supertest";
+import RedisStore from "connect-redis";
+import { createClient } from "redis";
+import { redisError } from "../../../router/user/error";
 import app from "../app";
+import { sequelize } from "../../../db/db";
+import create from "../../../user/create";
 
-describe("Request to verifyCode endpoint", () => {
-  it("should post to verifyCode endpoint", async () => {
+const redisClient = createClient();
+
+redisClient.connect().catch((error) => redisError(error));
+
+const redisStore = new RedisStore({
+  client: redisClient,
+});
+
+const user = {
+  username: "johndoe",
+  email: "john@doe.com",
+  password: "johndoe",
+};
+
+const CODE = "1234";
+
+describe("Redis operations", () => {
+  afterEach(() => sequelize.truncate());
+  afterEach(() =>
+    redisStore.client
+      .del([`signup:${user.email}`, `verification:${CODE}`])
+      .catch((error) => redisError(error)),
+  );
+  afterAll(() => sequelize.close());
+  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
+
+  it("should fail when code is invalid", async () => {
+    const data = JSON.stringify(user);
+    await redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() => redisStore.client.set(`verification:${CODE}`, user.email))
+      .catch((error) => redisError(error));
+
     const response = await request(app).post("/signup/verify-code").send({
-      code: 1234,
+      code: "0000",
     });
-    console.log("Status code", response.statusCode);
-    console.log("Error message", response.error);
-    console.log("Response body", response.body);
-    expect(response.body.message).toBe("Valid code");
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe("Invalid code");
   });
+
+  it("should fail to create user account if email exists but code is valid", async () => {
+    await create(user);
+    const data = JSON.stringify(user);
+    await redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() => redisStore.client.set(`verification:${CODE}`, user.email))
+      .catch((error) => redisError(error));
+
+    const response = await request(app).post("/signup/verify-code").send({
+      code: CODE,
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.body.error).toBe("Email already exists");
+  });
+
+  it("should create user account if code is valid and email is not taken", async () => {
+    const data = JSON.stringify(user);
+
+    redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() => redisStore.client.set(`verification:${CODE}`, user.email))
+      .catch((error) => redisError(error));
+
+    const response = await request(app).post("/signup/verify-code").send({
+      code: CODE,
+    });
+    expect(response.statusCode).toBe(201);
+    expect(response.body.message).toBe(
+      "Account successfully created, welcome johndoe!",
+    );
+  });
+
+  // FIXME:
+  // it("it should fail when the code expires", async () => {
+  //   const data = JSON.stringify(user);
+
+  //   await redisStore.client
+  //     .set(`signup:${user.email}`, data)
+  //     .then(() =>
+  //       redisStore.client
+  //         .set(`verification:${CODE}`, user.email)
+  //         .then(() => redisStore.client.expire(`verification:${CODE}`, -1)),
+  //     )
+  //     .catch((error) => redisError(error));
+
+  //   const response = await request(app)
+  //     .post("/signup/verify-code")
+  //     .send({ code: CODE });
+
+  //   expect(response.statusCode).toBe(400);
+  //   expect(response.body.error).toBe("Invalid code");
+  // });
+
+  // FIXME:
+  // it("it should fail when user data expires", async () => {
+  //   const data = JSON.stringify(user);
+
+  //   redisStore.client
+  //     .set(`signup:${user.email}`, data)
+  //     .then(() =>
+  //       redisStore.client
+  //         .set(`verification:${CODE}`, user.email)
+  //         .then(() => redisStore.client.expire(`signup:${user.email}`, -1)),
+  //     )
+  //     .catch((error) => redisError(error));
+
+  //   const response = await request(app)
+  //     .post("/signup/verify-code")
+  //     .send({ code: CODE });
+
+  //     console.log(response.body)
+  //   // expect(response.statusCode).toBe(401);
+  //   expect(response.body.error).toBe(
+  //     "Your session has expired. Please start new signup process",
+  //   );
+  // });
 });

--- a/packages/backend/src/user/create.ts
+++ b/packages/backend/src/user/create.ts
@@ -1,5 +1,7 @@
 import { UserAttrs, UserInstance, UserModel } from "./model";
 
-export const create = (user: UserAttrs): Promise<UserInstance> => {
+const create = (user: UserAttrs): Promise<UserInstance> => {
   return UserModel.create(user);
 };
+
+export default create;

--- a/packages/backend/src/user/find.ts
+++ b/packages/backend/src/user/find.ts
@@ -1,8 +1,32 @@
 import { UserModel } from "./model";
 
-export const findUserByEmail = (email: string) => {
+/**
+ * We call this [findUserByEmail] twice during the signup process;
+ *  1. During the signup form validation.
+ *     This ensures that candidate's data is checked and not saved
+ *     in Redis. This save some Redis resources and time.
+ *  2. During retrieving candidate's data from redis and saving it in the DB.
+ *
+ * Signup Context:
+ * A candidate initiates a signup process and submits the form, it is then
+ * validated. If it passes the validation check, the candidate's data
+ * is saved in Redis until when the candidate confirms the email by submiting
+ * the valid verification code sent to it. (The candidate can request to resend
+ * the verification code).
+ *
+ * If the candidate submits the valid verification code, their data is
+ * retrieved from the Redis Store.
+ * At this point we perform another findUserByEmail query to the database.
+ * It is important to do so because it is possible that two candidates
+ * attempted to signup using the same email, but one verified the email
+ * before the other. So we don't want to endup with duplicate emails.
+ */
+
+const findUserByEmail = (email: string) => {
   return UserModel.findOne({
     where: { email },
     attributes: { exclude: ["createdAt", "updatedAt"] },
   });
 };
+
+export default findUserByEmail;


### PR DESCRIPTION
This pull request solves tasks 10, 11, & 12 of https://github.com/lubegasimon/expense-tracker-mobile/issues/2  and depends on https://github.com/lubegasimon/expense-tracker-mobile/pull/18. This consists of six commits;
- The [first commit](https://github.com/lubegasimon/expense-tracker-mobile/commit/dd74646d14e815dcb75e4c1ac6be10bfac93581d) creates a `/verify-code` endpoint.
- The [second commit](https://github.com/lubegasimon/expense-tracker-mobile/commit/f76effa1d3a6d3bd04a94b0793c2cb1939c4b9ea) tests that the requests reach `verify-code` endpoint.
- The [third commit](https://github.com/lubegasimon/expense-tracker-mobile/commit/240007f36a9e8a4cefd0cda7bf01ebc7aad4ac08) exports `create` and `findUserByEmail` as main functions and also documents `findUserByEmail`.
- The [fourth commit](https://github.com/lubegasimon/expense-tracker-mobile/commit/12d822146b610dedd3b48f91fad856f429615cfe) ensures all redis keys are deleted after `redis.test.ts` run ends.
- The [fifth commit](https://github.com/lubegasimon/expense-tracker-mobile/commit/f7a26892dc9a81bbedb4d9b7bbe62dc01039ad63) adds the `verifyCode` route handler to serve requests to `/verify-code` endpoint.
- The [sixth commit](https://github.com/lubegasimon/expense-tracker-mobile/commit/916bb8b0c33a64cd20942e6413305dde37f0bb74) tests `verifyCode` route handler.