### PR TITLE
Change how verification code is saved in Redis

### DIFF
--- a/packages/backend/src/router/user/auth.ts
+++ b/packages/backend/src/router/user/auth.ts
@@ -8,7 +8,7 @@ function initializeSession(email: string, response: Response) {
   const JWT_SECRET = process.env.SECRET || "jwt-token";
   const token = jwt.sign({ email }, JWT_SECRET, { expiresIn: "7 days" });
   response.append("Authorization", `Bearer ${token}`);
-  response.status(201).json({
+  return response.status(201).json({
     message: `Successfully signed in`,
     token,
   });

--- a/packages/backend/src/test/redis.test.ts
+++ b/packages/backend/src/test/redis.test.ts
@@ -1,10 +1,9 @@
 import RedisStore from "connect-redis";
 import { createClient } from "redis";
-import { redisError } from "../router/user/error";
 
 const redisClient = createClient();
 
-redisClient.connect().catch((error) => redisError(error));
+redisClient.connect().catch(console.error);
 
 const redisStore = new RedisStore({
   client: redisClient,
@@ -15,20 +14,21 @@ const user = {
   email: "john@doe.com",
   password: "johndoe",
 };
+const CODE = "1234";
 
 describe("Redis operations", () => {
   afterAll(() =>
     redisStore.client
       .del([`signup:${user.email}`, `verification:${user.email}`])
-      .catch((error) => redisError(error)),
+      .catch(console.error),
   );
-  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
+  afterAll(() => redisClient.disconnect().catch(console.error));
 
   it("should save user data in Redis", async () => {
     const data = JSON.stringify(user);
     const response = await redisStore.client
       .set(`signup:${user.email}`, data)
-      .catch((error) => redisError(error));
+      .catch(console.error);
 
     expect(response).toBe("OK");
   });
@@ -36,7 +36,7 @@ describe("Redis operations", () => {
   it("should return null for invalid redis key", async () => {
     const response = await redisStore.client
       .get(`signup:*`)
-      .catch((error) => redisError(error));
+      .catch(console.error);
 
     expect(response).toBe(null);
   });
@@ -44,44 +44,42 @@ describe("Redis operations", () => {
   it("should return data associated to redis key", async () => {
     const response = await redisStore.client
       .get(`signup:${user.email}`)
-      .catch((error) => redisError(error));
+      .catch(console.error);
 
     expect(response).toBe(
       '{"username":"johndoe","email":"john@doe.com","password":"johndoe"}',
     );
   });
 
-  it("should set verification:<email> key in Redis", async () => {
-    const data = JSON.stringify(user);
+  it("should return OK for successful key save in Redis", async () => {
     const response = await redisStore.client
-      .set(`verification:${user.email}`, user.email)
-      .catch((error) => redisError(error));
+      .set(`verification:${user.email}`, CODE)
+      .catch(console.error);
 
     expect(response).toBe("OK");
   });
 
-  it("should retrieve email associated to verification:<email> key in Redis", async () => {
+  it("should return CODE associated to verification:email key in Redis", async () => {
     const response = await redisStore.client
       .get(`verification:${user.email}`)
-      .catch((error) => redisError(error));
+      .catch(console.error);
 
-    expect(response).toBe("john@doe.com");
+    expect(response).toBe("1234");
   });
 
-  it("should set verification:<email> key and expiry in Redis", async () => {
-    const data = JSON.stringify(user);
+  it("should return true and set expiry for verification:email key", async () => {
     const response = await redisStore.client
-      .set(`verification:${user.email}`, data)
-      .then((_) => redisStore.client.expire(`verification:${user.email}`, -1))
-      .catch((error) => redisError(error));
+      .set(`verification:${user.email}`, CODE)
+      .then(() => redisStore.client.expire(`verification:${user.email}`, -1))
+      .catch(console.error);
 
     expect(response).toBe(true);
   });
 
-  it("should fail to retrieve data when key expires", async () => {
+  it("should return null when key expires", async () => {
     const response = await redisStore.client
       .get(`verification:${user.email}`)
-      .catch((error) => redisError(error));
+      .catch(console.error);
 
     expect(response).toBe(null);
   });

--- a/packages/backend/src/test/user/create.test.ts
+++ b/packages/backend/src/test/user/create.test.ts
@@ -10,8 +10,7 @@ const user = {
 };
 
 describe("User CRUD operation", () => {
-  beforeEach(() => sequelize.truncate());
-
+  afterEach(() => sequelize.truncate());
   afterAll(() => sequelize.close());
 
   it("create user", () => {

--- a/packages/backend/src/test/user/find.test.ts
+++ b/packages/backend/src/test/user/find.test.ts
@@ -11,8 +11,7 @@ const user = {
 };
 
 describe("Find by email", () => {
-  beforeEach(() => sequelize.truncate());
-
+  afterEach(() => sequelize.truncate());
   afterAll(() => sequelize.close());
 
   it("should return user if email exists", async () => {

--- a/packages/backend/src/test/user/signup/email.test.ts
+++ b/packages/backend/src/test/user/signup/email.test.ts
@@ -30,7 +30,6 @@ describe("email edge cases", () => {
     );
   });
 
-  beforeEach(() => sequelize.truncate());
   afterEach(() => sequelize.truncate());
   afterAll(() => sequelize.close());
 

--- a/packages/backend/src/test/user/signup/password.test.ts
+++ b/packages/backend/src/test/user/signup/password.test.ts
@@ -14,11 +14,9 @@ describe("password edge case", () => {
       "Password must NOT have fewer than 5 characters",
     );
   });
-});
 
-/* TODO: Could be improved, but blocked:
+  /* TODO: Could be improved, but blocked:
    see -- https://stackoverflow.com/questions/79159863/typescript-seems-to-not-fully-support-data-option-for-const-validation */
-describe("cross password edge case", () => {
   it("should return 400 if passwords do not match", async () => {
     const response = await request(app).post("/signup").send({
       username: "johndoe",

--- a/packages/backend/src/test/user/signup/saveInRedis.test.ts
+++ b/packages/backend/src/test/user/signup/saveInRedis.test.ts
@@ -1,41 +1,30 @@
 import request from "supertest";
 import app from "../app";
-import { redisClient } from "../../../middleware/session";
-import { redisError } from "../../../router/user/error";
 
-const data = {
+const user = {
   username: "johndoe",
   email: "johnn@doe.com",
   password: "johndoe",
   confirmPassword: "johndoe",
 };
 
-describe("Check if candidate data and verification code are saved in Redis", () => {
-  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
-  afterEach(() =>
-    redisClient.del("signup*").catch((error) => redisError(error)),
-  );
-
+// TODO: Use stubs to avoid generating and sending different codes and emails respectively.
+describe("Check if candidate data is saved in Redis", () => {
   it("should return saved candidate's data ", async () => {
-    const response = await request(app).post("/signup").send(data);
+    const response = await request(app).post("/signup").send(user);
     expect(response.body.savedCandidateData).toBe(
       '{"username":"johndoe","email":"johnn@doe.com","password":"johndoe"}',
     );
   });
 
-  it("should return saved verification code, associated to candidate's email", async () => {
-    const response = await request(app).post("/signup").send(data);
-    expect(response.body.savedVerificationCode).toBe("johnn@doe.com");
-  });
-
-  // TODO: Use stubs because an email is sent whenever this test runs.
-  it("should send email to candidate's email", async () => {
+  it("should return 200 email to candidate's email", async () => {
     const response = await request(app).post("/signup").send({
       username: "johndoe",
       email: "lubegasimon73@gmail.com",
       password: "johndoe",
       confirmPassword: "johndoe",
     });
+    expect(response.statusCode).toBe(200);
     expect(response.body.sendEmailStatus).toBe("Email sent");
   });
 });

--- a/packages/backend/src/test/user/signup/verifyCode.test.ts
+++ b/packages/backend/src/test/user/signup/verifyCode.test.ts
@@ -1,14 +1,13 @@
 import request from "supertest";
 import RedisStore from "connect-redis";
 import { createClient } from "redis";
-import { redisError } from "../../../router/user/error";
 import app from "../app";
 import { sequelize } from "../../../db/db";
 import create from "../../../user/create";
 
 const redisClient = createClient();
 
-redisClient.connect().catch((error) => redisError(error));
+redisClient.connect().catch(console.error);
 
 const redisStore = new RedisStore({
   client: redisClient,
@@ -26,98 +25,116 @@ describe("Redis operations", () => {
   afterEach(() => sequelize.truncate());
   afterEach(() =>
     redisStore.client
-      .del([`signup:${user.email}`, `verification:${CODE}`])
-      .catch((error) => redisError(error)),
+      .del([`signup:${user.email}`, `verification:${user.email}`])
+      .catch(console.error),
   );
   afterAll(() => sequelize.close());
-  afterAll(() => redisClient.disconnect().catch((error) => redisError(error)));
+  afterAll(() => redisClient.disconnect().catch(console.error));
 
-  it("should fail when code is invalid", async () => {
+  it("should return 201 and create user account if code is valid and email is not taken", async () => {
     const data = JSON.stringify(user);
+
     await redisStore.client
       .set(`signup:${user.email}`, data)
-      .then(() => redisStore.client.set(`verification:${CODE}`, user.email))
-      .catch((error) => redisError(error));
+      .then(() => redisStore.client.set(`verification:${user.email}`, CODE))
+      .catch(console.error);
 
     const response = await request(app).post("/signup/verify-code").send({
-      code: "0000",
-    });
-    expect(response.statusCode).toBe(400);
-    expect(response.body.error).toBe("Invalid code");
-  });
-
-  it("should fail to create user account if email exists but code is valid", async () => {
-    await create(user);
-    const data = JSON.stringify(user);
-    await redisStore.client
-      .set(`signup:${user.email}`, data)
-      .then(() => redisStore.client.set(`verification:${CODE}`, user.email))
-      .catch((error) => redisError(error));
-
-    const response = await request(app).post("/signup/verify-code").send({
-      code: CODE,
-    });
-    expect(response.statusCode).toBe(409);
-    expect(response.body.error).toBe("Email already exists");
-  });
-
-  it("should create user account if code is valid and email is not taken", async () => {
-    const data = JSON.stringify(user);
-
-    redisStore.client
-      .set(`signup:${user.email}`, data)
-      .then(() => redisStore.client.set(`verification:${CODE}`, user.email))
-      .catch((error) => redisError(error));
-
-    const response = await request(app).post("/signup/verify-code").send({
+      email: user.email,
       code: CODE,
     });
     expect(response.statusCode).toBe(201);
     expect(response.body.message).toBe("Successfully signed in");
   });
 
-  // FIXME:
-  // it("it should fail when the code expires", async () => {
-  //   const data = JSON.stringify(user);
+  it("should return 409 if email exists but code is valid", async () => {
+    await create(user);
+    const data = JSON.stringify(user);
+    await redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() => redisStore.client.set(`verification:${user.email}`, CODE))
+      .catch(console.error);
 
-  //   await redisStore.client
-  //     .set(`signup:${user.email}`, data)
-  //     .then(() =>
-  //       redisStore.client
-  //         .set(`verification:${CODE}`, user.email)
-  //         .then(() => redisStore.client.expire(`verification:${CODE}`, -1)),
-  //     )
-  //     .catch((error) => redisError(error));
+    const response = await request(app).post("/signup/verify-code").send({
+      email: user.email,
+      code: CODE,
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.body.error).toBe("Email already exists");
+  });
 
-  //   const response = await request(app)
-  //     .post("/signup/verify-code")
-  //     .send({ code: CODE });
+  it("should 400 when code is invalid", async () => {
+    const data = JSON.stringify(user);
+    await redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() => redisStore.client.set(`verification:${user.email}`, CODE))
+      .catch(console.error);
 
-  //   expect(response.statusCode).toBe(400);
-  //   expect(response.body.error).toBe("Invalid code");
-  // });
+    const response = await request(app).post("/signup/verify-code").send({
+      email: user.email,
+      code: "0000",
+    });
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe("Invalid code");
+  });
 
-  // FIXME:
-  // it("it should fail when user data expires", async () => {
-  //   const data = JSON.stringify(user);
+  it("should 400 when code is not provided", async () => {
+    const data = JSON.stringify(user);
+    await redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() => redisStore.client.set(`verification:${user.email}`, CODE))
+      .catch(console.error);
 
-  //   redisStore.client
-  //     .set(`signup:${user.email}`, data)
-  //     .then(() =>
-  //       redisStore.client
-  //         .set(`verification:${CODE}`, user.email)
-  //         .then(() => redisStore.client.expire(`signup:${user.email}`, -1)),
-  //     )
-  //     .catch((error) => redisError(error));
+    const response = await request(app).post("/signup/verify-code").send({});
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe(
+      "Verification code expired or invalid email. Please request new code",
+    );
+  });
 
-  //   const response = await request(app)
-  //     .post("/signup/verify-code")
-  //     .send({ code: CODE });
+  it("should return 401 when user data expires", async () => {
+    const data = JSON.stringify(user);
 
-  //     console.log(response.body)
-  //   // expect(response.statusCode).toBe(401);
-  //   expect(response.body.error).toBe(
-  //     "Your session has expired. Please start new signup process",
-  //   );
-  // });
+    await redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() =>
+        redisStore.client
+          .set(`verification:${user.email}`, CODE)
+          .then(() => redisStore.client.expire(`signup:${user.email}`, -1)),
+      )
+      .catch(console.error);
+
+    const response = await request(app)
+      .post("/signup/verify-code")
+      .send({ email: user.email, code: CODE });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body.error).toBe(
+      "Your session has expired. Please start new signup process",
+    );
+  });
+
+  it("should return 400 when the code expires", async () => {
+    const data = JSON.stringify(user);
+
+    await redisStore.client
+      .set(`signup:${user.email}`, data)
+      .then(() =>
+        redisStore.client
+          .set(`verification:${user.email}`, CODE)
+          .then(() =>
+            redisStore.client.expire(`verification:${user.email}`, -1),
+          ),
+      )
+      .catch(console.error);
+
+    const response = await request(app)
+      .post("/signup/verify-code")
+      .send({ email: user.email, code: CODE });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe(
+      "Verification code expired or invalid email. Please request new code",
+    );
+  });
 });


### PR DESCRIPTION
This pull request;
- Changes how the verification code is saved in Redis. For example;

     **Now**:
     Key: `verification:email`
     Value`CODE`

    **Before**:
    Key: `verification:CODE`
    Value: `email`

- It updates and fixes bugs caused by coupling among all dependent tests.
- Improves code quality.

**Context:**
We changed how the verification code is saved in Redis because it is more efficient to update the value associated with a key in Redis for a new verification code request. For instance, a new code request carries an email in the request payload. The email is extracted and used to query and overwrite the value it is associated with.

In contrast to the current format, accessing a key associated with the email (value) is inefficient since Redis does not support reverse lookup (accessing key by value).
If we maintained this, we would need to store keys in the set with their values as the keys. That is, `email` (as key) would hold `verification:code` (as value) in the set. This was to add unnecessary complexity.