### PR TITLE
Reformat validation error response

### DIFF
--- a/packages/backend/src/middleware/validation/schemas/userSchema.ts
+++ b/packages/backend/src/middleware/validation/schemas/userSchema.ts
@@ -25,6 +25,7 @@ const userSchema: JSONSchemaType<User> = {
     properties: {
       username:
         "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
+      email: "Invalid email format",
       password: "Password must NOT have fewer than 5 characters",
       confirmPassword: "Passwords do not match",
     },

--- a/packages/backend/src/middleware/validation/validateRequestBody.ts
+++ b/packages/backend/src/middleware/validation/validateRequestBody.ts
@@ -39,14 +39,19 @@ const validateRequestBody = (schema: string) => {
     const data = request.body;
     const valid = validate && validate(data);
     if (!valid || data.password !== data.confirmPassword) {
-      const errors = validate?.errors;
+      let errors: { [key: string]: string | undefined } = {};
+      if (validate?.errors) {
+        for (const error of validate?.errors) {
+          const errorName = error.instancePath.slice(1);
+          errors[errorName] = error.message;
+        }
+      }
       response.status(400).json({ error: errors });
       return;
     }
     const rows = await findUserByEmail(data.email);
     if (!!rows) {
-      const error = "Email already exists";
-      response.status(409).json({ error });
+      response.status(409).json({ error: { email: "Email already exists" } });
       return;
     }
     next();

--- a/packages/backend/src/test/user/signup/email.test.ts
+++ b/packages/backend/src/test/user/signup/email.test.ts
@@ -12,9 +12,7 @@ describe("email edge cases", () => {
       confirmPassword: "johndoe",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toContain(
-      'must match format "email"',
-    );
+    expect(response.body.error.email).toContain("Invalid email format");
   });
 
   it("should return 400 for invalid email format", async () => {
@@ -25,9 +23,7 @@ describe("email edge cases", () => {
       confirmPassword: "johndoe",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toContain(
-      'must match format "email"',
-    );
+    expect(response.body.error.email).toContain("Invalid email format");
   });
 
   afterEach(() => sequelize.truncate());
@@ -43,6 +39,6 @@ describe("email edge cases", () => {
     await create(user);
     const response = await request(app).post("/signup").send(user);
     expect(response.status).toBe(409);
-    expect(response.body.error).toBe("Email already exists");
+    expect(response.body.error.email).toBe("Email already exists");
   });
 });

--- a/packages/backend/src/test/user/signup/password.test.ts
+++ b/packages/backend/src/test/user/signup/password.test.ts
@@ -10,7 +10,7 @@ describe("password edge case", () => {
       confirmPassword: "john",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toBe(
+    expect(response.body.error.password).toBe(
       "Password must NOT have fewer than 5 characters",
     );
   });
@@ -25,6 +25,6 @@ describe("password edge case", () => {
       confirmPassword: "johndo",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toBe("Passwords do not match");
+    expect(response.body.error.confirmPassword).toBe("Passwords do not match");
   });
 });

--- a/packages/backend/src/test/user/signup/username.test.ts
+++ b/packages/backend/src/test/user/signup/username.test.ts
@@ -21,7 +21,8 @@ describe("username edge cases", () => {
       confirmPassword: "johndoe",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toContain(
+    console.log("Response", response.body.error);
+    expect(response.body.error.username).toContain(
       "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
     );
   });
@@ -34,7 +35,7 @@ describe("username edge cases", () => {
       confirmPassword: "johndoe",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toContain(
+    expect(response.body.error.username).toContain(
       "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
     );
   });
@@ -47,7 +48,7 @@ describe("username edge cases", () => {
       confirmPassword: "johndoe",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toContain(
+    expect(response.body.error.username).toContain(
       "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
     );
   });
@@ -60,7 +61,7 @@ describe("username edge cases", () => {
       confirmPassword: "johndoe",
     });
     expect(response.status).toBe(400);
-    expect(response.body.error[0].message).toContain(
+    expect(response.body.error.username).toContain(
       "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
     );
   });


### PR DESCRIPTION
This pull request changes the validate middleware error response to be an object instead of an array. That is;

**Now:**
```
{
  confirmPassword: "Passwords do not match",
  email: "Invalid email format",
  password: "Password must NOT have fewer than 5 characters",
  username:
    "Username must be 5-10 characters long and can only contain letters, numbers, and underscores",
};
```

**Before:**
```
[
    {
      instancePath: "/email",
      keyword: "format",
      message: 'must match format "email"',
      params: [Object],
      schemaPath: "#/properties/email/format",
    },
    {
      instancePath: "/confirmPassword",
      keyword: "errorMessage",
      message: "Passwords do not match",
      params: [Object],
      schemaPath: "#/errorMessage",
    },
  ],
};
```