### PR TITLE
Enable view and hide password

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "expense-tracker",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/vector-icons": "^14.0.2",
+        "@expo/vector-icons": "^14.0.4",
         "@react-navigation/native": "^6.0.2",
         "@react-navigation/stack": "^6.4.1",
         "axios": "^1.7.7",
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -7243,6 +7243,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
@@ -7898,6 +7907,86 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -16421,6 +16510,21 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse-json": {
       "version": "5.2.0",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -16,7 +16,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.0.2",
+    "@expo/vector-icons": "^14.0.4",
     "@react-navigation/native": "^6.0.2",
     "@react-navigation/stack": "^6.4.1",
     "axios": "^1.7.7",

--- a/packages/mobile/src/components/EyeIcon/index.tsx
+++ b/packages/mobile/src/components/EyeIcon/index.tsx
@@ -1,0 +1,31 @@
+import { StyleSheet, Pressable } from "react-native";
+import Ionicons from "@expo/vector-icons/Ionicons";
+
+export interface ShowPasswordProps {
+  isShowPassword: boolean;
+  setShowPassword: () => void;
+}
+
+function EyeIcon({ isShowPassword, setShowPassword }: ShowPasswordProps) {
+  return (
+    <>
+      <Pressable style={style.icon} onPress={setShowPassword}>
+        <Ionicons
+          name={isShowPassword ? "eye" : "eye-off"}
+          size={25}
+          color="black"
+        />
+      </Pressable>
+    </>
+  );
+}
+
+const style = StyleSheet.create({
+  icon: {
+    position: "absolute",
+    right: 10,
+    padding: 4,
+  },
+});
+
+export default EyeIcon;

--- a/packages/mobile/src/components/Signup/ConfirmPassword.tsx
+++ b/packages/mobile/src/components/Signup/ConfirmPassword.tsx
@@ -1,8 +1,22 @@
 import { Text, TextInput, View } from "react-native";
-import { FieldProps } from "./types";
 import { inputStyle, errorStyle, inputAndErrorStyle } from "./styles";
+import { FieldProps } from "./types";
+import EyeIcon from "../EyeIcon";
 
-function ConfirmPassword({ value, onChange, error }: FieldProps) {
+export interface ConfirmPasswordProps extends FieldProps, ShowPasswordProps {}
+
+interface ShowPasswordProps {
+  isShowConfirmPassword: boolean;
+  setShowConfirmPassword: () => void;
+}
+
+function ConfirmPassword({
+  value,
+  onChange,
+  error,
+  isShowConfirmPassword,
+  setShowConfirmPassword,
+}: ConfirmPasswordProps) {
   return (
     <View style={inputAndErrorStyle.view}>
       <TextInput
@@ -11,7 +25,11 @@ function ConfirmPassword({ value, onChange, error }: FieldProps) {
         value={value}
         placeholder="Confirm Password"
         placeholderTextColor="gray"
-        secureTextEntry={true}
+        secureTextEntry={isShowConfirmPassword}
+      />
+      <EyeIcon
+        isShowPassword={isShowConfirmPassword}
+        setShowPassword={setShowConfirmPassword}
       />
       {error && <Text style={errorStyle.error}>{error}</Text>}
     </View>

--- a/packages/mobile/src/components/Signup/Password.tsx
+++ b/packages/mobile/src/components/Signup/Password.tsx
@@ -1,8 +1,16 @@
 import { TextInput, Text, View } from "react-native";
 import { FieldProps } from "./types";
 import { inputStyle, errorStyle, inputAndErrorStyle } from "./styles";
+import EyeIcon, { ShowPasswordProps } from "../EyeIcon";
+export interface PasswordProps extends FieldProps, ShowPasswordProps {}
 
-function Password({ value, onChange, error }: FieldProps) {
+function Password({
+  value,
+  onChange,
+  error,
+  isShowPassword,
+  setShowPassword,
+}: PasswordProps) {
   return (
     <View style={inputAndErrorStyle.view}>
       <TextInput
@@ -11,7 +19,11 @@ function Password({ value, onChange, error }: FieldProps) {
         value={value}
         placeholder="Password"
         placeholderTextColor="gray"
-        secureTextEntry={true}
+        secureTextEntry={isShowPassword}
+      />
+      <EyeIcon
+        isShowPassword={isShowPassword}
+        setShowPassword={setShowPassword}
       />
       {error && <Text style={errorStyle.error}>{error}</Text>}
     </View>

--- a/packages/mobile/src/screens/SignupScreen.tsx
+++ b/packages/mobile/src/screens/SignupScreen.tsx
@@ -18,6 +18,8 @@ function SignupForm() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(true);
+  const [showConfirmPassword, setConfirmShowPassword] = useState(true);
 
   function handleSubmit() {
     setLoading(true);
@@ -42,7 +44,15 @@ function SignupForm() {
   else
     return (
       <ErrorBoundary
-        fallback={<Text style={{ color: "red" }}>Something went wrong</Text>}
+        fallback={
+          <Text
+            style={{
+              color: "red",
+            }}
+          >
+            Something went wrong
+          </Text>
+        }
       >
         <KeyboardAvoidingView
           behavior={Platform.OS === "ios" ? "padding" : "height"}
@@ -62,11 +72,17 @@ function SignupForm() {
             value={password}
             onChange={setPassword}
             error={errors.password}
+            isShowPassword={showPassword}
+            setShowPassword={() => setShowPassword(!showPassword)}
           />
           <ConfirmPassword
             value={confirmPassword}
             onChange={setConfirmPassword}
             error={errors.confirmPassword}
+            isShowConfirmPassword={showConfirmPassword}
+            setShowConfirmPassword={() =>
+              setConfirmShowPassword(!showConfirmPassword)
+            }
           />
           <SignupButton onPress={handleSubmit} disabled={loading} />
         </KeyboardAvoidingView>

--- a/packages/mobile/src/screens/__tests__/__snapshots__/SignupScreen.tsx.snap
+++ b/packages/mobile/src/screens/__tests__/__snapshots__/SignupScreen.tsx.snap
@@ -109,6 +109,46 @@ exports[`<SignupForm/> Signup form contains username text input 1`] = `
       }
       value=""
     />
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "padding": 4,
+          "position": "absolute",
+          "right": 10,
+        }
+      }
+    >
+      <Text />
+    </View>
   </View>
   <View
     style={
@@ -137,6 +177,46 @@ exports[`<SignupForm/> Signup form contains username text input 1`] = `
       }
       value=""
     />
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "padding": 4,
+          "position": "absolute",
+          "right": 10,
+        }
+      }
+    >
+      <Text />
+    </View>
   </View>
   <View>
     <View


### PR DESCRIPTION
This pull request enables the viewing and hiding of passwords and solves the 'view password' tasks of https://github.com/lubegasimon/expense-tracker-mobile/issues/1.
- The eye icon can independently be toggled for both the `password` and `confirm password` fields.
- Long passwords do not overlap with the icon (See attached screenshots).

**Default UI**
![default behavior](https://github.com/user-attachments/assets/76756f00-dad5-4004-9364-f945c87ab7b3)

**toggle icon**

![toggle icon](https://github.com/user-attachments/assets/03b5c344-b9ce-46cc-b2e3-72abd1ff8215)

**very long password**

![very long password](https://github.com/user-attachments/assets/1381f48c-8951-4bad-b637-5c51304a1c5a)
  

