### PR TITLE
add verifyCode route to navigation stack

### DIFF
--- a/packages/mobile/src/app/signup.tsx
+++ b/packages/mobile/src/app/signup.tsx
@@ -1,5 +1,10 @@
+import { Link } from "expo-router";
 import SignupForm from "@/src/screens/SignupScreen";
 
 export default function Signup() {
-  return <SignupForm />;
+  return (
+    <Link href="/verifyCode">
+      <SignupForm />
+    </Link>
+  );
 }

--- a/packages/mobile/src/app/verifyCode.tsx
+++ b/packages/mobile/src/app/verifyCode.tsx
@@ -1,0 +1,5 @@
+import OtpScreen from "@/src/screens/OtpScreen";
+
+export default function VerifyCode() {
+  return <OtpScreen />;
+}

--- a/packages/mobile/src/screens/SignupScreen.tsx
+++ b/packages/mobile/src/screens/SignupScreen.tsx
@@ -1,6 +1,9 @@
 import { Text, StyleSheet, KeyboardAvoidingView, Platform } from "react-native";
 import { useState } from "react";
 import { AxiosResponse } from "axios";
+import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { RouteNavigationStack } from "@/src/types";
 import { axiosInstance } from "../api/axios";
 import { signupApi } from "../api/endpoints";
 import Username from "../components/Signup/Username";
@@ -11,6 +14,11 @@ import SignupButton from "../components/Signup/SignupButton";
 import Loader from "../components/Loader/loader";
 import ErrorBoundary from "../components/ErrorBoundary/ErrorBoundary";
 
+type VerifyCodeNavigationProp = StackNavigationProp<
+  RouteNavigationStack,
+  "verifyCode"
+>;
+
 function SignupForm() {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
@@ -20,6 +28,7 @@ function SignupForm() {
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(true);
   const [showConfirmPassword, setConfirmShowPassword] = useState(true);
+  const navigation = useNavigation<VerifyCodeNavigationProp>();
 
   function handleSubmit() {
     setLoading(true);
@@ -31,6 +40,7 @@ function SignupForm() {
         confirmPassword,
       })
       .then((_response: AxiosResponse) => {
+        navigation.navigate("verifyCode");
         setLoading(false);
         setErrors({});
       })

--- a/packages/mobile/src/types.ts
+++ b/packages/mobile/src/types.ts
@@ -1,3 +1,4 @@
 export type RouteNavigationStack = {
   signup: undefined;
+  verifyCode: undefined;
 };


### PR DESCRIPTION
This pull request adds the `verifyCode` route on the navigation stack such that on submitting signup form, the app navigates to the OtpScreen  ( part of https://github.com/lubegasimon/expense-tracker-mobile/issues/1 ). 