### PR TITLE
Alter categories table

### DIFF
--- a/packages/backend/migrations/20250116130053-alter-category.ts
+++ b/packages/backend/migrations/20250116130053-alter-category.ts
@@ -1,0 +1,14 @@
+import { QueryInterface, DataTypes } from "sequelize";
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.removeColumn("Categories", "details");
+    await queryInterface.addColumn("Categories", "description", {
+      type: DataTypes.STRING,
+    });
+  },
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.addColumn("Categories", "details", {
+      type: DataTypes.STRING,
+    });
+  },
+};

--- a/packages/backend/src/category/model.ts
+++ b/packages/backend/src/category/model.ts
@@ -11,7 +11,7 @@ type UUID = string;
 export interface CategoryAttrs {
   id?: UUID;
   name: string;
-  details?: string;
+  description?: string;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -30,7 +30,7 @@ export default (sequelize: Sequelize) => {
         type: DataTypes.STRING,
         allowNull: false,
       },
-      details: {
+      description: {
         type: DataTypes.TEXT,
         validate: {
           len: [0, 256],

--- a/packages/backend/src/category/update.ts
+++ b/packages/backend/src/category/update.ts
@@ -2,8 +2,8 @@ import models from "../models";
 import { CategoryAttrs } from "./model";
 
 const updateCategory = async (category: CategoryAttrs) => {
-  const { id, name, details } = category;
-  return await models.Category.update({ name, details }, { where: { id } });
+  const { id, name, description } = category;
+  return await models.Category.update({ name, description }, { where: { id } });
 };
 
 export default updateCategory;

--- a/packages/backend/src/middleware/validation/schemas/category/categorySchema.ts
+++ b/packages/backend/src/middleware/validation/schemas/category/categorySchema.ts
@@ -2,20 +2,20 @@ import { JSONSchemaType } from "ajv";
 
 interface CategoryBody {
   name: string;
-  details: string;
+  description: string;
 }
 
 const categoryBodySchema: JSONSchemaType<CategoryBody> = {
   type: "object",
   properties: {
     name: { type: "string" },
-    details: { type: "string", maxLength: 256 },
+    description: { type: "string", maxLength: 256 },
   },
   required: ["name"],
   additionalProperties: false,
   errorMessage: {
     properties: {
-      details: "Password must NOT have more than 256 characters",
+      description: "Password must NOT have more than 256 characters",
     },
   },
 };

--- a/packages/backend/src/router/category/create.ts
+++ b/packages/backend/src/router/category/create.ts
@@ -9,19 +9,19 @@ router.post(
   "/",
   validateCreateCategoryRequest(),
   async (request: Request, response: Response) => {
-    const { name, details } = request.body;
+    const { name, description } = request.body;
     const category = await findCategory(name);
     if (category)
       response.status(409).json({ message: "Category already exists" });
     else
-      await create({ name, details })
+      await create({ name, description })
         .then((category) => {
           return response.status(201).json({
             message: `Category ${name} successfully created`,
             category: {
               id: category.id,
               name,
-              details,
+              description,
             },
           });
         })

--- a/packages/backend/src/router/category/create.ts
+++ b/packages/backend/src/router/category/create.ts
@@ -12,12 +12,12 @@ router.post(
     const { name, description } = request.body;
     const category = await findCategory(name);
     if (category)
-      response.status(409).json({ message: "Category already exists" });
+      response.status(409).json({ message: `${name} already exists` });
     else
       await create({ name, description })
         .then((category) => {
           return response.status(201).json({
-            message: `Category ${name} successfully created`,
+            message: `${name} successfully created`,
             category: {
               id: category.id,
               name,

--- a/packages/backend/src/router/category/delete.ts
+++ b/packages/backend/src/router/category/delete.ts
@@ -13,17 +13,18 @@ router.delete("/:id", async (request: Request, response: Response) => {
       .then((result) => {
         if (result !== 1)
           return response.status(500).json({
-            message: `Failed to delete the category. Please try again`,
+            message: `Failed to delete the ${category.name}. Please try again`,
           });
         return response
           .status(200)
-          .json({ message: "Category successfully deleted" });
+          .json({ message: `${category.name} successfully deleted` });
       })
       .catch((error) => {
         console.error(`An error occured while deleting category: ${error}`);
-        return response
-          .status(500)
-          .json({ message: "Something went wrong. Please try again" });
+        return response.status(500).json({
+          message:
+            "An error occurred while deleting category. Please try again",
+        });
       });
   }
 });

--- a/packages/backend/src/router/category/edit.ts
+++ b/packages/backend/src/router/category/edit.ts
@@ -5,16 +5,16 @@ const router = Router();
 
 router.put("/:id", async (request: Request, response: Response) => {
   const id = request.params.id;
-  const { name, details } = request.body;
+  const { name, description } = request.body;
   if (!name) response.status(400).json({ message: "Name is required" });
   else
-    await updateCategory({ id, name, details })
+    await updateCategory({ id, name, description })
       .then(([result]) => {
         if (result !== 1)
           return response.status(404).json({ message: "Category not found" });
         return response.status(200).json({
           message: `Category successfully updated`,
-          category: { id, name, details },
+          category: { id, name, description },
         });
       })
       .catch((error) => {

--- a/packages/backend/src/router/category/edit.ts
+++ b/packages/backend/src/router/category/edit.ts
@@ -19,9 +19,10 @@ router.put("/:id", async (request: Request, response: Response) => {
       })
       .catch((error) => {
         console.error(`An error occured while updating category: ${error}`);
-        return response
-          .status(500)
-          .json({ message: "Something went wrong. Please try again" });
+        return response.status(500).json({
+          message:
+            "An error occurred while updating category. Please try again",
+        });
       });
 });
 

--- a/packages/backend/src/test/category/integration/create.test.ts
+++ b/packages/backend/src/test/category/integration/create.test.ts
@@ -19,19 +19,19 @@ describe("POST /category/create", () => {
       .post("/category/create")
       .send({
         name: "Water",
-        details: "Water bill",
+        description: "Water bill",
       })
       .expect(201);
     expect(response.body.message).toBe("Category Water successfully created");
     expect(response.body.category).toHaveProperty("name", "Water");
-    expect(response.body.category).toHaveProperty("details", "Water bill");
+    expect(response.body.category).toHaveProperty("description", "Water bill");
     expect(response.body.category).toHaveProperty("id");
   });
 
   it("should return 409 for a category name that exists", async () => {
     const category = {
       name: "Water",
-      details: "Water bills",
+      description: "Water bills",
     };
     const response = await request(app)
       .post("/category/create")

--- a/packages/backend/src/test/category/integration/create.test.ts
+++ b/packages/backend/src/test/category/integration/create.test.ts
@@ -14,29 +14,28 @@ describe("POST /category/create", () => {
     await closeRedisClient();
   });
 
-  it("should return 200 when category is created", async () => {
+  it("should return 201 when category is created", async () => {
     const response = await request(app)
       .post("/category/create")
       .send({
-        name: "Water",
-        description: "Water bill",
+        name: "Utilities",
+        description:
+          "Payments for water, electricity, gas, garbage, sewage, et cetera",
       })
       .expect(201);
-    expect(response.body.message).toBe("Category Water successfully created");
-    expect(response.body.category).toHaveProperty("name", "Water");
-    expect(response.body.category).toHaveProperty("description", "Water bill");
+    expect(response.body.message).toBe("Utilities successfully created");
+    expect(response.body.category).toHaveProperty("name", "Utilities");
     expect(response.body.category).toHaveProperty("id");
   });
 
   it("should return 409 for a category name that exists", async () => {
     const category = {
-      name: "Water",
-      description: "Water bills",
+      name: "Utilities",
     };
     const response = await request(app)
       .post("/category/create")
       .send(category)
       .expect(409);
-    expect(response.body.message).toBe("Category already exists");
+    expect(response.body.message).toBe("Utilities already exists");
   });
 });

--- a/packages/backend/src/test/category/integration/delete.test.ts
+++ b/packages/backend/src/test/category/integration/delete.test.ts
@@ -10,7 +10,7 @@ const id = uuidv4();
 const category = {
   id,
   name: "Water",
-  details: "Water bill",
+  description: "Water bill",
 };
 
 describe("DELETE /category/:id", () => {

--- a/packages/backend/src/test/category/integration/delete.test.ts
+++ b/packages/backend/src/test/category/integration/delete.test.ts
@@ -9,8 +9,8 @@ import { closeRedisClient } from "../../../middleware/session";
 const id = uuidv4();
 const category = {
   id,
-  name: "Water",
-  description: "Water bill",
+  name: "Housing",
+  description: "Payment for rent, mortgage, property taxes, et cetera",
 };
 
 describe("DELETE /category/:id", () => {
@@ -26,7 +26,7 @@ describe("DELETE /category/:id", () => {
   it("should return 200 when category is successfully deleted", async () => {
     await create(category);
     const response = await request(app).delete(`/category/${id}`).expect(200);
-    expect(response.body.message).toBe("Category successfully deleted");
+    expect(response.body.message).toBe(`${category.name} successfully deleted`);
   });
 
   it("should return 404 if a category ID is invalid", async () => {

--- a/packages/backend/src/test/category/integration/edit.test.ts
+++ b/packages/backend/src/test/category/integration/edit.test.ts
@@ -10,7 +10,7 @@ const id = uuidv4();
 const category = {
   id,
   name: "Water",
-  details: "Water bill",
+  description: "Water bill",
 };
 
 describe("PUT /category/:id", () => {
@@ -29,19 +29,19 @@ describe("PUT /category/:id", () => {
       .put(`/category/${id}`)
       .send({
         name: "Electricity",
-        details: "Electricity bills",
+        description: "Electricity bills",
       })
       .expect(200);
     expect(response.body.message).toBe("Category successfully updated");
     expect(response.body.category).toHaveProperty("name", "Electricity");
     expect(response.body.category).toHaveProperty(
-      "details",
+      "description",
       "Electricity bills",
     );
     expect(response.body.category).toHaveProperty("id", `${id}`);
   });
 
-  it("should return 200 when category details is not provided", async () => {
+  it("should return 200 when category description is not provided", async () => {
     const response = await request(app)
       .put(`/category/${id}`)
       .send({
@@ -58,12 +58,12 @@ describe("PUT /category/:id", () => {
       .put(`/category/${id}`)
       .send({
         name: "Internet",
-        details: "",
+        description: "",
       })
       .expect(200);
     expect(response.body.message).toBe("Category successfully updated");
     expect(response.body.category).toHaveProperty("name", "Internet");
-    expect(response.body.category).toHaveProperty("details", "");
+    expect(response.body.category).toHaveProperty("description", "");
     expect(response.body.category).toHaveProperty("id", `${id}`);
   });
 
@@ -71,7 +71,7 @@ describe("PUT /category/:id", () => {
     const response = await request(app)
       .put(`/category/${id}`)
       .send({
-        details: "Electricity bills",
+        description: "Electricity bills",
       })
       .expect(400);
     expect(response.body.message).toBe("Name is required");

--- a/packages/backend/src/test/category/integration/edit.test.ts
+++ b/packages/backend/src/test/category/integration/edit.test.ts
@@ -9,8 +9,8 @@ import { closeRedisClient } from "../../../middleware/session";
 const id = uuidv4();
 const category = {
   id,
-  name: "Water",
-  description: "Water bill",
+  name: "Housing",
+  description: "Payment for rent, mortgage, property taxes, et cetera",
 };
 
 describe("PUT /category/:id", () => {
@@ -28,15 +28,19 @@ describe("PUT /category/:id", () => {
     const response = await request(app)
       .put(`/category/${id}`)
       .send({
-        name: "Electricity",
-        description: "Electricity bills",
+        name: "Internet and Communication",
+        description:
+          "Payment for internet services, mobile phone plans, et cetera",
       })
       .expect(200);
     expect(response.body.message).toBe("Category successfully updated");
-    expect(response.body.category).toHaveProperty("name", "Electricity");
+    expect(response.body.category).toHaveProperty(
+      "name",
+      "Internet and Communication",
+    );
     expect(response.body.category).toHaveProperty(
       "description",
-      "Electricity bills",
+      "Payment for internet services, mobile phone plans, et cetera",
     );
     expect(response.body.category).toHaveProperty("id", `${id}`);
   });
@@ -53,25 +57,11 @@ describe("PUT /category/:id", () => {
     expect(response.body.category).toHaveProperty("id", `${id}`);
   });
 
-  it("should return 200 when category update is successfull", async () => {
-    const response = await request(app)
-      .put(`/category/${id}`)
-      .send({
-        name: "Internet",
-        description: "",
-      })
-      .expect(200);
-    expect(response.body.message).toBe("Category successfully updated");
-    expect(response.body.category).toHaveProperty("name", "Internet");
-    expect(response.body.category).toHaveProperty("description", "");
-    expect(response.body.category).toHaveProperty("id", `${id}`);
-  });
-
   it("should return 400 when category name is not provided", async () => {
     const response = await request(app)
       .put(`/category/${id}`)
       .send({
-        description: "Electricity bills",
+        description: "Others bills",
       })
       .expect(400);
     expect(response.body.message).toBe("Name is required");
@@ -81,7 +71,7 @@ describe("PUT /category/:id", () => {
     const invalidId = uuidv4();
     const response = await request(app)
       .put(`/category/${invalidId}`)
-      .send({ name: "Rent" })
+      .send({ name: "Housing" })
       .expect(404);
     expect(response.body.message).toBe("Category not found");
   });

--- a/packages/backend/src/test/category/integration/index.test.ts
+++ b/packages/backend/src/test/category/integration/index.test.ts
@@ -9,8 +9,8 @@ import { closeRedisClient } from "../../../middleware/session";
 const id = uuidv4();
 
 const category = {
-  name: "Water",
-  description: "Water bill",
+  name: "Groceries",
+  description: "Payment for food and household supplies for consumption",
   id,
 };
 

--- a/packages/backend/src/test/category/integration/index.test.ts
+++ b/packages/backend/src/test/category/integration/index.test.ts
@@ -10,7 +10,7 @@ const id = uuidv4();
 
 const category = {
   name: "Water",
-  details: "Water bill",
+  description: "Water bill",
   id,
 };
 

--- a/packages/backend/src/test/category/unit/create.test.ts
+++ b/packages/backend/src/test/category/unit/create.test.ts
@@ -6,7 +6,7 @@ import models from "../../../models";
 const category = {
   id: uuidv4(),
   name: "Water",
-  details: "Water bill",
+  description: "Water bill",
 };
 
 describe("Create category", () => {

--- a/packages/backend/src/test/category/unit/create.test.ts
+++ b/packages/backend/src/test/category/unit/create.test.ts
@@ -5,8 +5,8 @@ import models from "../../../models";
 
 const category = {
   id: uuidv4(),
-  name: "Water",
-  description: "Water bill",
+  name: "Furnishings and Appliances",
+  description: "Purchases for furniture, appliances, and decorations",
 };
 
 describe("Create category", () => {
@@ -18,7 +18,7 @@ describe("Create category", () => {
 
   it("create category if name doesn't exist", async () => {
     return await create(category).then((category) =>
-      expect(category).toHaveProperty("name", "Water"),
+      expect(category).toHaveProperty("name", "Furnishings and Appliances"),
     );
   });
 });

--- a/packages/backend/src/test/category/unit/delete.test.ts
+++ b/packages/backend/src/test/category/unit/delete.test.ts
@@ -17,7 +17,7 @@ describe("DELETE category", () => {
     const createdCategory = await create({
       id,
       name: "Water",
-      details: "Water bill",
+      description: "Water bill",
     });
     expect(createdCategory).toHaveProperty("name", "Water");
 

--- a/packages/backend/src/test/category/unit/delete.test.ts
+++ b/packages/backend/src/test/category/unit/delete.test.ts
@@ -16,10 +16,11 @@ describe("DELETE category", () => {
   it("should delete category", async () => {
     const createdCategory = await create({
       id,
-      name: "Water",
-      description: "Water bill",
+      name: "Transportation",
+      description:
+        "Costs for fuel, car maintenance, public transportation, car registration et cetera",
     });
-    expect(createdCategory).toHaveProperty("name", "Water");
+    expect(createdCategory).toHaveProperty("name", "Transportation");
 
     const result = await deleteCategory(id);
     expect(result).toEqual(1);

--- a/packages/backend/src/test/category/unit/find.test.ts
+++ b/packages/backend/src/test/category/unit/find.test.ts
@@ -9,7 +9,7 @@ const id = uuidv4();
 const category = {
   id,
   name: "Water",
-  details: "Water bill",
+  description: "Water bill",
 };
 
 describe("find category name", () => {

--- a/packages/backend/src/test/category/unit/find.test.ts
+++ b/packages/backend/src/test/category/unit/find.test.ts
@@ -8,8 +8,8 @@ const id = uuidv4();
 
 const category = {
   id,
-  name: "Water",
-  description: "Water bill",
+  name: "Insurance",
+  description: "Costs for home, healthy, life, and asset insurance policies",
 };
 
 describe("find category name", () => {
@@ -22,7 +22,7 @@ describe("find category name", () => {
   it("should return category if it exists", async () => {
     await create(category);
     const result = await findCategoryById(id);
-    expect(result).toHaveProperty("name", "Water");
+    expect(result).toHaveProperty("name", "Insurance");
     expect(result).toHaveProperty("id", id);
   });
 

--- a/packages/backend/src/test/category/unit/update.test.ts
+++ b/packages/backend/src/test/category/unit/update.test.ts
@@ -9,8 +9,7 @@ const id = uuidv4();
 
 const category = {
   id,
-  name: "Water",
-  description: "Water bill",
+  name: "Childcare and Education",
 };
 
 describe("Update category", () => {
@@ -24,28 +23,31 @@ describe("Update category", () => {
     await create(category);
     const [result] = await updateCategory({
       ...category,
-      description: "About water bills",
+      description:
+        "Payment for daycare, school supplies, tuition, extracurricular, et cetera",
     });
     const updatedCategory = await findCategoryById(id);
     expect(result).toEqual(1);
-    expect(updatedCategory).toHaveProperty("description", "About water bills");
+    expect(updatedCategory).toHaveProperty(
+      "description",
+      "Payment for daycare, school supplies, tuition, extracurricular, et cetera",
+    );
   });
 
   it("should update category name and description", async () => {
     const [result] = await updateCategory({
       id,
-      name: "Electricity",
-      description: "Electricity bills",
+      name: "Healthcare",
+      description: "Costs for medical treatments, wellness services et cetera",
     });
     const updatedCategory = await findCategoryById(id);
     expect(result).toEqual(1);
-    expect(updatedCategory).toHaveProperty("name", "Electricity");
-    expect(updatedCategory).toHaveProperty("description", "Electricity bills");
+    expect(updatedCategory).toHaveProperty("name", "Healthcare");
   });
 
   it("should return 0 if category with specified ID doesn't exist", async () => {
     const invalidId = uuidv4();
-    const [result] = await updateCategory({ id: invalidId, name: "Water" });
+    const [result] = await updateCategory({ id: invalidId, name: "Petcare" });
     expect(result).toEqual(0);
   });
 });

--- a/packages/backend/src/test/category/unit/update.test.ts
+++ b/packages/backend/src/test/category/unit/update.test.ts
@@ -10,7 +10,7 @@ const id = uuidv4();
 const category = {
   id,
   name: "Water",
-  details: "Water bill",
+  description: "Water bill",
 };
 
 describe("Update category", () => {
@@ -20,27 +20,27 @@ describe("Update category", () => {
   );
   afterAll(() => sequelize.close());
 
-  it("should update category details", async () => {
+  it("should update category description", async () => {
     await create(category);
     const [result] = await updateCategory({
       ...category,
-      details: "About water bills",
+      description: "About water bills",
     });
     const updatedCategory = await findCategoryById(id);
     expect(result).toEqual(1);
-    expect(updatedCategory).toHaveProperty("details", "About water bills");
+    expect(updatedCategory).toHaveProperty("description", "About water bills");
   });
 
-  it("should update category name and details", async () => {
+  it("should update category name and description", async () => {
     const [result] = await updateCategory({
       id,
       name: "Electricity",
-      details: "Electricity bills",
+      description: "Electricity bills",
     });
     const updatedCategory = await findCategoryById(id);
     expect(result).toEqual(1);
     expect(updatedCategory).toHaveProperty("name", "Electricity");
-    expect(updatedCategory).toHaveProperty("details", "Electricity bills");
+    expect(updatedCategory).toHaveProperty("description", "Electricity bills");
   });
 
   it("should return 0 if category with specified ID doesn't exist", async () => {

--- a/packages/backend/src/test/expense/unit/create.test.ts
+++ b/packages/backend/src/test/expense/unit/create.test.ts
@@ -6,7 +6,7 @@ import models from "../../../models";
 const expense = {
   id: uuidv4(),
   name: "Water bill",
-  details: "For January",
+  details: "Water bill for January",
   amount: 20,
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -19,7 +19,7 @@ describe("Create expense", () => {
   it("create expense", async () => {
     return await create(expense).then(async (expense) => {
       expect(expense).toHaveProperty("name", "Water bill");
-      expect(expense).toHaveProperty("amount");
+      expect(expense).toHaveProperty("amount", 20);
     });
   });
 });

--- a/packages/backend/src/test/expense/unit/delete.test.ts
+++ b/packages/backend/src/test/expense/unit/delete.test.ts
@@ -8,8 +8,8 @@ const id = uuidv4();
 
 const expense = {
   id,
-  name: "Water bill",
-  details: "For January",
+  name: "Gym membership",
+  details: "Gym membership for January",
   amount: 20,
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -21,8 +21,8 @@ describe("DELETE expense", () => {
 
   it("should delete expense", async () => {
     const createdExpense = await create(expense);
-    expect(createdExpense).toHaveProperty("name", "Water bill");
-    expect(createdExpense).toHaveProperty("amount");
+    expect(createdExpense).toHaveProperty("name", "Gym membership");
+    expect(createdExpense).toHaveProperty("amount", 20);
 
     const result = await deleteExpense(id);
     expect(result).toEqual(1);

--- a/packages/backend/src/test/expense/unit/find.test.ts
+++ b/packages/backend/src/test/expense/unit/find.test.ts
@@ -8,8 +8,7 @@ const id = uuidv4();
 
 const expense = {
   id,
-  name: "Water bill",
-  details: "For January",
+  name: "Personal loan",
   amount: 20,
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -22,8 +21,7 @@ describe("find expense", () => {
   it("should return expense if it exists", async () => {
     await create(expense);
     const result = await findExpenseById(id);
-    expect(result).toHaveProperty("name", "Water bill");
-    expect(result).toHaveProperty("amount");
+    expect(result).toHaveProperty("name", "Personal loan");
   });
 
   it("should return null if expense does not exist or is empty", async () => {

--- a/packages/backend/src/test/expense/unit/update.test.ts
+++ b/packages/backend/src/test/expense/unit/update.test.ts
@@ -53,7 +53,7 @@ describe("Update expense", () => {
     const category = await createCategory({
       id: categoryId,
       name: "Internet",
-      details: "Internet for January",
+      description: "Internet for January",
     });
     const [result] = await updateExpense({
       ...expense,

--- a/packages/backend/src/test/expense/unit/update.test.ts
+++ b/packages/backend/src/test/expense/unit/update.test.ts
@@ -10,7 +10,7 @@ const id = uuidv4();
 
 const expense = {
   id,
-  name: "Water bill",
+  name: "Birthday gift",
   amount: 20,
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -28,32 +28,40 @@ describe("Update expense", () => {
     await create(expense);
     const [result] = await updateExpense({
       ...expense,
-      details: "For January",
+      details: "Doe's 26th birthday gift",
     });
     const updatedExpense = await findExpenseById(id);
     expect(result).toEqual(1);
-    expect(updatedExpense).toHaveProperty("details", "For January");
+    expect(updatedExpense).toHaveProperty(
+      "details",
+      "Doe's 26th birthday gift",
+    );
   });
 
   it("should update expense name, amount, and details ", async () => {
     const [result] = await updateExpense({
       id,
-      name: "Electricity",
+      name: "Wedding pledge",
       amount: 30,
-      details: "For February",
+      details: "Pledge fullfulment for Doe's wedding",
     });
     const updatedExpense = await findExpenseById(id);
     expect(result).toEqual(1);
-    expect(updatedExpense).toHaveProperty("name", "Electricity");
-    expect(updatedExpense).toHaveProperty("details", "For February");
+    expect(updatedExpense).toHaveProperty("name", "Wedding pledge");
+    expect(updatedExpense).toHaveProperty(
+      "details",
+      "Pledge fullfulment for Doe's wedding",
+    );
+    expect(updatedExpense).toHaveProperty("amount", 30);
   });
 
   it("should change expense category", async () => {
     const categoryId = uuidv4();
     const category = await createCategory({
       id: categoryId,
-      name: "Internet",
-      description: "Internet for January",
+      name: "Miscellaneous",
+      description:
+        "Any unclassified expenses, such as gifts, donations, personal indulgences",
     });
     const [result] = await updateExpense({
       ...expense,


### PR DESCRIPTION
This pull request;
- alters column `details` (introduced in https://github.com/lubegasimon/expense-tracker-mobile/issues/40) to `description` for the `categories` table
- Changes all occurrences of `details` to `description` in the category.
- improves response messages for the `create`, `update/edit`, and `delete` category operations.
- Improves tests by using intuitive expense categories, that is,
```
category-name : "Utilites",
description   : "Payments for water, electricity, gas, garbage, sewage, et cetera"
```