### PR TITLE
refactor error object for validateSignupRequest

### DIFF
--- a/packages/backend/src/middleware/validation/signup/validate.ts
+++ b/packages/backend/src/middleware/validation/signup/validate.ts
@@ -8,7 +8,11 @@ const validateSignupRequest = () => {
     const { email } = request.body;
     findUserByEmail(email)
       .then((user) => {
-        if (user) return next({ status: 409, message: "Email already exists" });
+        if (user)
+          return next({
+            status: 409,
+            message: { emailExists: "Email already exists" },
+          });
         else return next();
       })
       .catch(next);

--- a/packages/backend/src/test/user/signup-integration/email.test.ts
+++ b/packages/backend/src/test/user/signup-integration/email.test.ts
@@ -51,6 +51,6 @@ describe("email edge cases", () => {
     await create(user);
     const response = await request(app).post("/signup").send(user).expect(409);
 
-    expect(response.body.error).toBe("Email already exists");
+    expect(response.body.error.emailExists).toBe("Email already exists");
   });
 });

--- a/packages/backend/src/test/user/signup-integration/verifyCode.test.ts
+++ b/packages/backend/src/test/user/signup-integration/verifyCode.test.ts
@@ -21,7 +21,6 @@ describe("Redis operations", () => {
       .catch(console.error),
   );
   afterAll(async () => await sequelize.close());
-  // afterAll(async () => await redisClient.disconnect().catch(console.error));
   afterAll(async () => {
     await closeRedisClient();
   });


### PR DESCRIPTION
This PR updates the `... signup/validate.ts` middleware to modify the error response for an existing email during signup. Previously, the error was returned silently and hidden from the user, but now it is shown to the user (accessed by the frontend via `error.response.data.error.userExists`).