### PR TITLE
[mobile] show error to user during signup if email exists

### DIFF
--- a/packages/mobile/src/screens/SignupScreen.tsx
+++ b/packages/mobile/src/screens/SignupScreen.tsx
@@ -13,6 +13,7 @@ import ConfirmPassword from "../components/Signup/ConfirmPassword";
 import SignupButton from "../components/Signup/SignupButton";
 import Loader from "../components/Loader/loader";
 import ErrorBoundary from "../components/ErrorBoundary/ErrorBoundary";
+import Error from "../components/Error/Error";
 
 type VerifyCodeNavigationProp = StackNavigationProp<
   RouteNavigationStack,
@@ -74,6 +75,7 @@ function SignupForm() {
             {" "}
             Create your account{" "}
           </Text>
+          <Error error={errors.emailExists} />
           <Username
             value={username}
             onChange={setUsername}


### PR DESCRIPTION
This PR improves UX by displaying an error message if a candidate attempts to sign up with an existing email. Previously, it was a silent error that caused the app to crash. See https://github.com/lubegasimon/expense-tracker-mobile/pull/76 for context.

**Before:**


https://github.com/user-attachments/assets/f942f480-e8aa-4329-9b7f-80f6e7850bd6



![Screenshot 2025-01-26 at 14 15 31](https://github.com/user-attachments/assets/1cca1693-f288-4345-93d7-eace30e3c64e)

**Now**:

https://github.com/user-attachments/assets/a80ee4a0-2bce-4245-ae9e-59cbf8b5f135

![Screenshot 2025-01-26 at 14 18 51](https://github.com/user-attachments/assets/0abc8004-c9bf-4051-8b99-ca7fe82eb708)
