### PR TITLE
[backend] Refactor expense response object

### DIFF
--- a/packages/backend/src/expense/formatDate.ts
+++ b/packages/backend/src/expense/formatDate.ts
@@ -1,0 +1,7 @@
+import { format, parse } from "date-fns";
+
+export const formatClientDate = (date: string | undefined) =>
+  date ? parse(date, "dd/MM/yyyy", new Date()) : undefined;
+
+export const formatServerDate = (date: Date | undefined | null) =>
+  !(date instanceof Date) || !date ? undefined : format(date, "dd/MM/yyyy");

--- a/packages/backend/src/expense/formatDate.ts
+++ b/packages/backend/src/expense/formatDate.ts
@@ -1,7 +1,26 @@
 import { format, parse } from "date-fns";
 
 export const formatClientDate = (date: string | undefined) =>
-  date ? parse(date, "dd/MM/yyyy", new Date()) : undefined;
+  date
+    ? new Date(
+        Date.UTC(
+          parse(date, "dd/MM/yyyy", new Date()).getFullYear(),
+          parse(date, "dd/MM/yyyy", new Date()).getMonth(),
+          parse(date, "dd/MM/yyyy", new Date()).getDate(),
+        ),
+      )
+    : undefined;
 
 export const formatServerDate = (date: Date | undefined | null) =>
-  !(date instanceof Date) || !date ? undefined : format(date, "dd/MM/yyyy");
+  !(date instanceof Date) || !date
+    ? undefined
+    : format(
+        new Date(
+          Date.UTC(
+            date.getUTCFullYear(),
+            date.getUTCMonth(),
+            date.getUTCDate(),
+          ),
+        ),
+        "dd/MM/yyyy",
+      );

--- a/packages/backend/src/expense/operations/find.ts
+++ b/packages/backend/src/expense/operations/find.ts
@@ -1,3 +1,6 @@
 import models from "../../models";
 
-export const findExpenseById = (id: string) => models.Expense.findByPk(id);
+export const findExpenseById = (id: string) =>
+  models.Expense.findByPk(id, {
+    include: [{ model: models.Category, attributes: ["name"] }],
+  });

--- a/packages/backend/src/expense/router/create.ts
+++ b/packages/backend/src/expense/router/create.ts
@@ -1,24 +1,30 @@
 import { Request, Response, Router } from "express";
 import create from "../operations/create";
-import { findCategoryById } from "../../category/operations/find";
+import { findCategory } from "../../category/operations/find";
+import { formatClientDate, formatServerDate } from "../formatDate";
 
 const router = Router();
 
 router.post("/", async (request: Request, response: Response) => {
-  const { name, amount, details, date, categoryId } = request.body;
+  const { name, amount, details, createdAt, category } = request.body;
 
-  const category = await findCategoryById(categoryId);
-  create({ name, amount, details, createdAt: date, categoryId })
+  const categoryData =
+    category === undefined ? null : await findCategory(category);
+
+  create({
+    name,
+    amount,
+    details,
+    createdAt: formatClientDate(createdAt),
+    categoryId: categoryData?.id,
+  })
     .then((expense) =>
       response.status(201).json({
         message: `Expense successfully created`,
         expense: {
-          id: expense.id,
-          name,
-          amount,
-          details,
-          date,
-          category: category ? category.name : "",
+          ...expense.dataValues,
+          createdAt: formatServerDate(expense?.createdAt),
+          category,
         },
       }),
     )

--- a/packages/backend/src/test/expense/integration/create.test.ts
+++ b/packages/backend/src/test/expense/integration/create.test.ts
@@ -9,9 +9,7 @@ describe("POST /expense/create", () => {
   afterAll(() => models.Expense.destroy({ truncate: true }));
   afterAll(() => models.Category.destroy({ truncate: true, cascade: true }));
   afterAll(() => sequelize.close());
-  afterAll(() => {
-    closeRedisClient();
-  });
+  afterAll(() => closeRedisClient());
 
   it("should return 201 when expense is created", async () => {
     const category = await createCategory({ name: "Utility" });
@@ -20,7 +18,8 @@ describe("POST /expense/create", () => {
       .send({
         name: "Water bill",
         amount: 20,
-        categoryId: category.id,
+        category: category.name,
+        createdAt: "06/02/2025",
       })
       .expect(201);
     expect(response.body.message).toBe("Expense successfully created");
@@ -28,5 +27,18 @@ describe("POST /expense/create", () => {
     expect(response.body.expense).toHaveProperty("amount", 20);
     expect(response.body.expense).toHaveProperty("id");
     expect(response.body.expense).toHaveProperty("category", category.name);
+    expect(response.body.expense).toHaveProperty("categoryId", category.id);
+    expect(response.body.expense).toHaveProperty("createdAt", "06/02/2025");
+  });
+
+  it("should return 201 when expense is created and category is null", async () => {
+    const response = await request(app)
+      .post("/expense/create")
+      .send({
+        name: "Water bill",
+        amount: 20,
+      })
+      .expect(201);
+    expect(response.body.expense).toHaveProperty("categoryId", null);
   });
 });

--- a/packages/backend/src/test/expense/unit/find.test.ts
+++ b/packages/backend/src/test/expense/unit/find.test.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
-import create from "../../../expense/operations/create";
+import createExpense from "../../../expense/operations/create";
+import createCategory from "../../../category/operations/create";
 import { sequelize } from "../../../../db/db";
 import { findExpenseById } from "../../../expense/operations/find";
 import models from "../../../models";
@@ -16,16 +17,42 @@ const expense = {
 
 describe("find expense", () => {
   afterEach(() => models.Expense.destroy({ truncate: true }));
+  afterAll(() => models.Category.destroy({ truncate: true, cascade: true }));
   afterAll(() => sequelize.close());
 
   it("should return expense if it exists", async () => {
-    await create(expense);
+    await createExpense(expense);
     const result = await findExpenseById(id);
     expect(result).toHaveProperty("name", "Personal loan");
+    expect(result).toHaveProperty("Category", null);
+  });
+
+  it("should return expense if it exists", async () => {
+    const category = {
+      id: uuidv4(),
+      name: "Recreational and Entertainment",
+      description:
+        "Costs for hobbies, leisure activities, gym memberships, streaming subscriptions et cetera",
+    };
+
+    const anotherExpense = {
+      ...expense,
+      categoryId: category.id,
+    };
+
+    await createCategory(category);
+    await createExpense(anotherExpense);
+    const result = await findExpenseById(anotherExpense.id);
+    expect(result).toHaveProperty("name", "Personal loan");
+    expect(result).toHaveProperty("categoryId", category.id);
+    expect(result).toHaveProperty(
+      "Category.dataValues.name",
+      "Recreational and Entertainment",
+    );
   });
 
   it("should return null if expense does not exist or is empty", async () => {
-    await create(expense);
+    await createExpense(expense);
     const invalidId = uuidv4();
     const result = await findExpenseById(invalidId);
     expect(result).toBeNull();

--- a/packages/backend/src/test/expense/unit/formatDate.test.ts
+++ b/packages/backend/src/test/expense/unit/formatDate.test.ts
@@ -1,0 +1,26 @@
+import {
+  formatClientDate,
+  formatServerDate,
+} from "../../../expense/formatDate";
+
+describe("Format Date", () => {
+  it("should convert client date string to server Date", () => {
+    const date = formatClientDate("06/02/2025");
+    expect(date!.toISOString()).toBe("2025-02-05T21:00:00.000Z");
+  });
+
+  it("should convert undefined client date to undefined server Date", () => {
+    const date = formatClientDate(undefined);
+    expect(date).toBeUndefined();
+  });
+
+  it("should server Date to client date string", () => {
+    const date = formatServerDate(new Date("2025-02-05T21:00:00.000Z"));
+    expect(date).toBe("06/02/2025");
+  });
+
+  it("should convert undefined server date to undefined client Date", () => {
+    const date = formatServerDate(undefined);
+    expect(date).toBeUndefined();
+  });
+});

--- a/packages/backend/src/test/expense/unit/formatDate.test.ts
+++ b/packages/backend/src/test/expense/unit/formatDate.test.ts
@@ -6,7 +6,7 @@ import {
 describe("Format Date", () => {
   it("should convert client date string to server Date", () => {
     const date = formatClientDate("06/02/2025");
-    expect(date!.toISOString()).toBe("2025-02-05T21:00:00.000Z");
+    expect(date!.toISOString()).toBe("2025-02-06T00:00:00.000Z");
   });
 
   it("should convert undefined client date to undefined server Date", () => {
@@ -16,7 +16,7 @@ describe("Format Date", () => {
 
   it("should server Date to client date string", () => {
     const date = formatServerDate(new Date("2025-02-05T21:00:00.000Z"));
-    expect(date).toBe("06/02/2025");
+    expect(date).toBe("05/02/2025");
   });
 
   it("should convert undefined server date to undefined client Date", () => {


### PR DESCRIPTION
This PR refactors the `expense` response object to contain a `category` (`category.name`). This makes it convenient for the front end to consume via `response.data.Category.name`.

The PR also implements `formatClientDate` and `formatServerDate.`
- `formatClientDate` converts the client date (in the form `DD/MM/YYYY`) to the ISO 8601 standard (`YYYY-MM-DDTHH:MM:SS.sssZ`).
- `formatServerDate` converts ISO 8601 standard to `DD/MM/YYYY` format for the client.

However, this is not an efficient approach as it involves parsing dates to and fro; I propose (in https://github.com/lubegasimon/expense-tracker-mobile/issues/82 )to have a standardized Date format across the client and the server.