### PR TITLE
[backend] Refactor expense responses to find and edit endpoints

### DIFF
--- a/packages/backend/src/expense/operations/update.ts
+++ b/packages/backend/src/expense/operations/update.ts
@@ -1,7 +1,7 @@
 import models from "../../models";
 import { ExpenseAttrs } from "../model";
 
-const updateExpense = (expense: ExpenseAttrs) => {
+const editExpense = (expense: ExpenseAttrs) => {
   const { id, name, details, amount, categoryId } = expense;
   return models.Expense.update(
     { name, details, amount, categoryId },
@@ -9,4 +9,4 @@ const updateExpense = (expense: ExpenseAttrs) => {
   );
 };
 
-export default updateExpense;
+export default editExpense;

--- a/packages/backend/src/expense/router/edit.ts
+++ b/packages/backend/src/expense/router/edit.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import updateExpense from "../operations/update";
+import editExpense from "../operations/update";
 import { findCategory } from "../../category/operations/find";
 import { formatClientDate, formatServerDate } from "../formatDate";
 
@@ -25,7 +25,7 @@ router.put("/:id", async (request: Request, response: Response) => {
   else if (!amount)
     response.status(400).json({ message: "Amount is required" });
   else
-    updateExpense(expense)
+    editExpense(expense)
       .then(([result]) => {
         if (result !== 1)
           return response.status(404).json({

--- a/packages/backend/src/expense/router/edit.ts
+++ b/packages/backend/src/expense/router/edit.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import editExpense from "../operations/update";
 import { findCategory } from "../../category/operations/find";
-import { formatClientDate, formatServerDate } from "../formatDate";
+import { formatClientDate } from "../formatDate";
 
 const router = Router();
 
@@ -33,11 +33,6 @@ router.put("/:id", async (request: Request, response: Response) => {
           });
         return response.status(200).json({
           message: "Expense successfully updated",
-          expense: {
-            ...expense,
-            createdAt: formatServerDate(expense?.createdAt),
-            category,
-          },
         });
       })
       .catch((error) => {

--- a/packages/backend/src/expense/router/find.ts
+++ b/packages/backend/src/expense/router/find.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { findExpenseById } from "../operations/find";
+import { formatServerDate } from "../formatDate";
 
 const router = Router();
 
@@ -9,7 +10,13 @@ router.get("/:id", (request: Request, response: Response) => {
     .then((expense) => {
       if (!expense)
         return response.status(404).json({ message: "Expense not found" });
-      else return response.status(200).json({ expense });
+      else
+        return response.status(200).json({
+          expense: {
+            ...expense.dataValues,
+            createdAt: formatServerDate(expense.createdAt),
+          },
+        });
     })
     .catch((error) => {
       console.error(`Error occurred while fetching expense by Id: ${error}`);

--- a/packages/backend/src/test/expense/integration/edit.test.ts
+++ b/packages/backend/src/test/expense/integration/edit.test.ts
@@ -44,16 +44,7 @@ describe("PUT /expense/:id", () => {
       })
       .expect(200);
     expect(response.body.message).toBe("Expense successfully updated");
-    expect(response.body.expense).toHaveProperty("name", "Apple music");
-    expect(response.body.expense).toHaveProperty(
-      "details",
-      "February subscription",
-    );
-    expect(response.body.expense).toHaveProperty("amount", 10);
-    expect(response.body.expense).toHaveProperty("id", `${id}`);
-    expect(response.body.expense).toHaveProperty("categoryId", category.id);
-    expect(response.body.expense).toHaveProperty("category", category.name);
-    expect(response.body.expense).toHaveProperty("createdAt", DATE);
+    expect(response.body.expense).toBeUndefined();
   });
 
   it("should return 200 when expense details and category are not provided", async () => {
@@ -65,9 +56,7 @@ describe("PUT /expense/:id", () => {
       })
       .expect(200);
     expect(response.body.message).toBe("Expense successfully updated");
-    expect(response.body.expense).toHaveProperty("name", "Dog food");
-    expect(response.body.expense).toHaveProperty("amount", 10);
-    expect(response.body.expense).toHaveProperty("id", `${id}`);
+    expect(response.body.expense).toBeUndefined();
   });
 
   it("should return 400 when expense name is not provided", async () => {

--- a/packages/backend/src/test/expense/integration/find.test.ts
+++ b/packages/backend/src/test/expense/integration/find.test.ts
@@ -12,6 +12,7 @@ const expense = {
   name: "Netflix",
   amount: 10,
   details: "January subscription",
+  createdAt: new Date("2025-01-05T21:00:00.000Z"),
 };
 
 describe("GET /expense/:id", () => {
@@ -32,7 +33,7 @@ describe("GET /expense/:id", () => {
     );
     expect(response.body.expense).toHaveProperty("amount", 10);
     expect(response.body.expense).toHaveProperty("id", `${id}`);
-    expect(response.body.expense).toHaveProperty("createdAt");
+    expect(response.body.expense).toHaveProperty("createdAt", "05/01/2025");
   });
 
   it("should return 404 if a expense is not found", async () => {

--- a/packages/backend/src/test/expense/unit/update.test.ts
+++ b/packages/backend/src/test/expense/unit/update.test.ts
@@ -3,7 +3,7 @@ import { sequelize } from "../../../../db/db";
 import models from "../../../models";
 import create from "../../../expense/operations/create";
 import createCategory from "../../../category/operations/create";
-import updateExpense from "../../../expense/operations/update";
+import editExpense from "../../../expense/operations/update";
 import { findExpenseById } from "../../../expense/operations/find";
 
 const id = uuidv4();
@@ -23,33 +23,30 @@ describe("Update expense", () => {
 
   it("should update expense details", async () => {
     await create(expense);
-    const [result] = await updateExpense({
+    const [result] = await editExpense({
       ...expense,
       details: "Doe's 26th birthday gift",
     });
-    const updatedExpense = await findExpenseById(id);
+    const editedExpense = await findExpenseById(id);
     expect(result).toEqual(1);
-    expect(updatedExpense).toHaveProperty(
-      "details",
-      "Doe's 26th birthday gift",
-    );
+    expect(editedExpense).toHaveProperty("details", "Doe's 26th birthday gift");
   });
 
   it("should update expense name, amount, and details ", async () => {
-    const [result] = await updateExpense({
+    const [result] = await editExpense({
       id,
       name: "Wedding pledge",
       amount: 30,
       details: "Pledge fullfulment for Doe's wedding",
     });
-    const updatedExpense = await findExpenseById(id);
+    const editedExpense = await findExpenseById(id);
     expect(result).toEqual(1);
-    expect(updatedExpense).toHaveProperty("name", "Wedding pledge");
-    expect(updatedExpense).toHaveProperty(
+    expect(editedExpense).toHaveProperty("name", "Wedding pledge");
+    expect(editedExpense).toHaveProperty(
       "details",
       "Pledge fullfulment for Doe's wedding",
     );
-    expect(updatedExpense).toHaveProperty("amount", 30);
+    expect(editedExpense).toHaveProperty("amount", 30);
   });
 
   it("should change expense category", async () => {
@@ -60,18 +57,18 @@ describe("Update expense", () => {
       description:
         "Any unclassified expenses, such as gifts, donations, personal indulgences",
     });
-    const [result] = await updateExpense({
+    const [result] = await editExpense({
       ...expense,
       categoryId: category.id,
     });
-    const updatedExpense = await findExpenseById(id);
+    const editedExpense = await findExpenseById(id);
     expect(result).toEqual(1);
-    expect(updatedExpense).toHaveProperty("categoryId", categoryId);
+    expect(editedExpense).toHaveProperty("categoryId", categoryId);
   });
 
   it("should return 0 if expense with specified ID doesn't exist", async () => {
     const invalidId = uuidv4();
-    const [result] = await updateExpense({
+    const [result] = await editExpense({
       ...expense,
       id: invalidId,
     });

--- a/packages/backend/src/user/router/sendCode.ts
+++ b/packages/backend/src/user/router/sendCode.ts
@@ -37,7 +37,7 @@ async function sendCodeToEmail(email: string) {
       if (response[0].statusCode) return "Email sent";
     })
     .catch((error) => {
-      console.error("Error response body: ", error.response.body)
+      console.error("Error response body: ", error.response.body);
       throw new Error("Something went wrong while sending code to the email");
     });
 }


### PR DESCRIPTION
This PR ensures the client receives the `DD/MM/YYYY` Date format from the server instead of the ISO 8601 standard format. It also avoids returning the `expense` in the response object for a successful request to the `editExpense` endpoint because the `expense` is never consumed by the front end.