### PR TITLE
[backend] Compile category body schema

### DIFF
--- a/packages/backend/src/middleware/validation/schemas/category/categorySchema.ts
+++ b/packages/backend/src/middleware/validation/schemas/category/categorySchema.ts
@@ -15,7 +15,7 @@ const categoryBodySchema: JSONSchemaType<CategoryBody> = {
   additionalProperties: false,
   errorMessage: {
     properties: {
-      description: "Password must NOT have more than 256 characters",
+      description: "Description must NOT have more than 256 characters",
     },
   },
 };

--- a/packages/backend/src/middleware/validation/validateRequest.ts
+++ b/packages/backend/src/middleware/validation/validateRequest.ts
@@ -4,6 +4,7 @@ import addFormats from "ajv-formats";
 import addErrors from "ajv-errors";
 import loginBodySchema from "./schemas/user/loginSchema";
 import signupBodySchema from "./schemas/user/signupSchema";
+import categoryBodySchema from "./schemas/category/categorySchema";
 
 const ajv = new Ajv({ allErrors: true, $data: true });
 addFormats(ajv);
@@ -21,6 +22,7 @@ ajv.addFormat("username", /^[0-9a-zA-Z_]{5,10}$/);
 */
 ajv.addSchema(loginBodySchema, "loginBodySchema");
 ajv.addSchema(signupBodySchema, "signupBodySchema");
+ajv.addSchema(categoryBodySchema, "categoryBodySchema");
 
 const validateRequest = (
   schema: string,
@@ -45,8 +47,13 @@ const validateRequest = (
     let errors: { [key: string]: string | undefined } = {};
     if (validate?.errors) {
       for (const error of validate?.errors) {
-        const errorName = error.instancePath.slice(1);
-        errors[errorName] = error.message;
+        if (error.instancePath.length === 0 && error.keyword === "required") {
+          const errorName: string = error.params.missingProperty;
+          errors[errorName] = `${errorName} is required`;
+        } else {
+          const errorName = error.instancePath.slice(1);
+          errors[errorName] = error.message;
+        }
       }
       return next({ status: 400, message: errors });
     }

--- a/packages/backend/src/test/category/integration/create.test.ts
+++ b/packages/backend/src/test/category/integration/create.test.ts
@@ -23,6 +23,19 @@ describe("POST /category/create", () => {
     expect(response.body.category).toHaveProperty("id");
   });
 
+  it("should return 400 when category name in not provided", async () => {
+    const response = await request(app)
+      .post("/category/create")
+      .send({
+        description:
+          "Payments for water, electricity, gas, garbage, sewage, et cetera",
+      })
+      .expect(400);
+    console.log("Response body ->", response.body);
+    expect(response.body.error.name).toBe("name is required");
+    expect(response.body.category).toBeUndefined();
+  });
+
   it("should return 409 for a category name that exists", async () => {
     const category = {
       name: "Utilities",


### PR DESCRIPTION
This PR ensures that `categoryBodySchema` is compiled when a request is made to `category/create` endpoint