### PR TITLE
[backend] refactor/remove expense from response

### DIFF
--- a/packages/backend/src/expense/router/create.ts
+++ b/packages/backend/src/expense/router/create.ts
@@ -1,7 +1,7 @@
 import { Request, Response, Router } from "express";
 import create from "../operations/create";
 import { findCategory } from "../../category/operations/find";
-import { formatClientDate, formatServerDate } from "../formatDate";
+import { formatClientDate } from "../formatDate";
 import validateCreateExpenseRequest from "../../middleware/validation/expense/validate";
 
 const router = Router();
@@ -22,14 +22,9 @@ router.post(
       createdAt: formatClientDate(createdAt),
       categoryId: categoryData?.id,
     })
-      .then((expense) =>
+      .then(() =>
         response.status(201).json({
           message: `Expense successfully created`,
-          expense: {
-            ...expense.dataValues,
-            createdAt: formatServerDate(expense?.createdAt),
-            category,
-          },
         }),
       )
       .catch((error) => {

--- a/packages/backend/src/test/expense/integration/create.test.ts
+++ b/packages/backend/src/test/expense/integration/create.test.ts
@@ -23,12 +23,7 @@ describe("POST /expense/create", () => {
       })
       .expect(201);
     expect(response.body.message).toBe("Expense successfully created");
-    expect(response.body.expense).toHaveProperty("name", "Water bill");
-    expect(response.body.expense).toHaveProperty("amount", 20);
-    expect(response.body.expense).toHaveProperty("id");
-    expect(response.body.expense).toHaveProperty("category", category.name);
-    expect(response.body.expense).toHaveProperty("categoryId", category.id);
-    expect(response.body.expense).toHaveProperty("createdAt", "06/02/2025");
+    expect(response.body.expense).toBeUndefined();
   });
 
   it("should return 201 when details, category, and createdAt are not provided", async () => {
@@ -39,10 +34,8 @@ describe("POST /expense/create", () => {
         amount: 20,
       })
       .expect(201);
-    expect(response.body.expense.name).toBe("Water bill");
-    expect(response.body.expense.amount).toBe(20);
-    expect(response.body.expense.details).toBeNull();
-    expect(response.body.expense.categoryId).toBeNull();
+    expect(response.body.message).toBe("Expense successfully created");
+    expect(response.body.expense).toBeUndefined();
   });
 
   it("should return 400 when expense name and amount are missing", async () => {


### PR DESCRIPTION
This PR removes the created expense from the response in the `expense/create` route because the front end never consumes the expense.

