### PR TITLE
[backend] chore/use AJV to validate formats inline

### DIFF
--- a/packages/backend/src/middleware/validation/schemas/expense/expenseSchema.ts
+++ b/packages/backend/src/middleware/validation/schemas/expense/expenseSchema.ts
@@ -8,6 +8,8 @@ interface ExpenseBody {
   createdAt: string;
 }
 
+const dateRegex = /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/;
+
 const expenseBodySchema: JSONSchemaType<ExpenseBody> = {
   type: "object",
   properties: {
@@ -15,7 +17,7 @@ const expenseBodySchema: JSONSchemaType<ExpenseBody> = {
     amount: { type: "number" },
     category: { type: "string" },
     details: { type: "string", maxLength: 256 },
-    createdAt: { type: "string", format: "date" },
+    createdAt: { type: "string", pattern: dateRegex.source },
   },
   required: ["name", "amount"],
   additionalProperties: false,

--- a/packages/backend/src/middleware/validation/schemas/user/signupSchema.ts
+++ b/packages/backend/src/middleware/validation/schemas/user/signupSchema.ts
@@ -7,11 +7,12 @@ interface SignupBody {
   confirmPassword: string;
 }
 
+const usernameRegex = /^[0-9a-zA-Z_]{5,10}$/;
+
 const signupBodySchema: JSONSchemaType<SignupBody> = {
   type: "object",
   properties: {
-    /* Note: "username" is a custom format, see ../validateRequest.ts */
-    username: { type: "string", format: "username" },
+    username: { type: "string", pattern: usernameRegex.source },
     email: { type: "string", format: "email" },
     password: { type: "string", minLength: 5, maxLength: 256 },
     confirmPassword: {

--- a/packages/backend/src/middleware/validation/validateRequest.ts
+++ b/packages/backend/src/middleware/validation/validateRequest.ts
@@ -11,12 +11,6 @@ const ajv = new Ajv({ allErrors: true, $data: true });
 addFormats(ajv);
 addErrors(ajv);
 
-const dateRegex = /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/;
-const usernameRegex = /^[0-9a-zA-Z_]{5,10}$/;
-
-ajv.addFormat("username", usernameRegex);
-ajv.addFormat("date", dateRegex);
-
 /*
   By using ajv.addSchema, we ensure that schema compilations happen only once,
   but validations happen multiple times, this is best for performance


### PR DESCRIPTION
This PR implements `username` and `date` format validation using inline `AJV` patterns. Since these formats are not reused in other schemas, inlining them makes more sense.