### PR TITLE
[mobile] Feature/filter expense by date service

### DIFF
--- a/packages/mobile/src/api/endpoints.ts
+++ b/packages/mobile/src/api/endpoints.ts
@@ -2,6 +2,4 @@ export const signupApi = "/signup";
 export const verifyCode = "signup/verify-code";
 export const resendCode = "signup/resend-code";
 export const createExpense = "/expense/create";
-export const getExpenses = "/expense";
-export const editExpense = "/expense";
-export const findExpense = "/expense";
+export const getExpensesByDate = "/expenses";

--- a/packages/mobile/src/components/Expenses/index.tsx
+++ b/packages/mobile/src/components/Expenses/index.tsx
@@ -26,7 +26,7 @@ function EmptyList() {
           padding: 50,
         }}
       >
-        <Text style={{ fontSize: 30 }}>No expenses yet</Text>
+        <Text style={{ fontSize: 30 }}>No expenses yet today</Text>
       </View>
     </View>
   );
@@ -40,29 +40,34 @@ function Expenses({ expenses, error }: ExpensesProps) {
           <Text style={styles.header}>Name</Text>
           <Text style={styles.header}>Amount</Text>
         </View>
-        <Error error={error} />
-        <FlatList
-          data={expenses}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => {
-            const { name, amount } = item;
-            return (
-              <View style={styles.row}>
-                <Text style={styles.cell}>{name}</Text>
-                <Text style={styles.cell}>{amount}</Text>
-              </View>
-            );
-          }}
-          ListEmptyComponent={EmptyList}
-        />
+        {error ? (
+          <Error error={error} />
+        ) : (
+          <FlatList
+            data={expenses}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => {
+              const { name, amount } = item;
+              return (
+                <View style={styles.row}>
+                  <Text style={styles.cell}>{name}</Text>
+                  <Text style={styles.cell}>{amount}</Text>
+                </View>
+              );
+            }}
+            ListEmptyComponent={EmptyList}
+          />
+        )}
       </View>
-      <AddExpense />
+      <View style={{ paddingLeft: 10 }}>
+        <AddExpense />
+      </View>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { padding: 10, height: "90%" },
+  container: { paddingLeft: 10, height: "90%" },
   row: {
     flexDirection: "row",
     justifyContent: "space-between",

--- a/packages/mobile/src/components/FilterExpenses/index.tsx
+++ b/packages/mobile/src/components/FilterExpenses/index.tsx
@@ -1,0 +1,99 @@
+import { useState, useCallback } from "react";
+import { View } from "react-native";
+import { Button } from "react-native-paper";
+import { DatePickerModal } from "react-native-paper-dates";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { axiosInstance } from "@/src/api/axios";
+import { getExpensesByDate } from "@/src/api/endpoints";
+import { expense } from "../Expenses";
+import { catchError } from "@/src/util";
+
+interface FilterExpensesProps {
+  date: Date | undefined;
+  setDate: React.Dispatch<React.SetStateAction<Date | undefined>>;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+  expenses: expense[];
+  setExpenses: React.Dispatch<React.SetStateAction<expense[]>>;
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const splitDate = (date: Date) => date.toISOString().split("T")[0];
+
+function FilterExpensesByDate({
+  date,
+  setDate,
+  expenses,
+  setExpenses,
+  setLoading,
+  setError,
+}: FilterExpensesProps) {
+  const [open, setOpen] = useState(false);
+
+  const onDismissSingle = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+
+  //TODO: This Filters for a single date, not the date range
+  function onFilterByDate(date: Date | undefined) {
+    if (!date) {
+      /** Renders the current component if date is undefined this avoids unnecessary API call */
+      setExpenses(expenses);
+    } else {
+      const queryDate = splitDate(
+        new Date(date.getFullYear(), date.getMonth(), date.getDate()),
+      );
+
+      setLoading(true);
+      axiosInstance
+        .get(`${getExpensesByDate}?date=${queryDate}`)
+        .then((response) => {
+          setExpenses(response.data.expenses);
+          setError("");
+        })
+        .catch((error) => catchError(error, setError))
+        .finally(() => setLoading(false));
+    }
+  }
+
+  const onConfirmSingle = useCallback(
+    (params: { [key: string]: Date | undefined }) => {
+      setOpen(false);
+      setDate(params.date);
+      onFilterByDate(params.date);
+    },
+    [setOpen, setDate],
+  );
+
+  return (
+    <SafeAreaProvider>
+      <View
+        style={{
+          padding: 10,
+          justifyContent: "center",
+          alignItems: "flex-start",
+        }}
+      >
+        <Button onPress={() => setOpen(true)} uppercase={false} mode="outlined">
+          {date
+            ? `Expenses for ${date.toLocaleDateString()}`
+            : "Today's expenses"}
+        </Button>
+        <DatePickerModal
+          disableStatusBarPadding
+          locale="en"
+          presentationStyle="pageSheet"
+          mode="single"
+          startWeekOnMonday={true}
+          visible={open}
+          onDismiss={onDismissSingle}
+          date={date}
+          onConfirm={onConfirmSingle}
+          onChange={() => setDate}
+          saveLabel="Apply"
+        />
+      </View>
+    </SafeAreaProvider>
+  );
+}
+
+export default FilterExpensesByDate;

--- a/packages/mobile/src/components/__tests__/Expenses.tsx
+++ b/packages/mobile/src/components/__tests__/Expenses.tsx
@@ -74,7 +74,7 @@ describe("<Expenses Component/>", () => {
     ).toJSON();
 
     expect(tree).toMatchSnapshot();
-    expect(screen.getByText("No expenses yet")).toBeTruthy();
+    expect(screen.getByText("No expenses yet today")).toBeTruthy();
   });
 
   it("should render an error message when there is an error", () => {

--- a/packages/mobile/src/components/__tests__/__snapshots__/Expenses.tsx.snap
+++ b/packages/mobile/src/components/__tests__/__snapshots__/Expenses.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Expenses Component/> renders the header correctly 1`] = `
     style={
       {
         "height": "90%",
-        "padding": 10,
+        "paddingLeft": 10,
       }
     }
   >
@@ -164,17 +164,25 @@ exports[`<Expenses Component/> renders the header correctly 1`] = `
       </View>
     </RCTScrollView>
   </View>
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
+  <View
     style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
+      {
+        "paddingLeft": 10,
+      }
     }
-  />
+  >
+    <RNCSafeAreaProvider
+      onInsetsChange={[Function]}
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
 </RCTSafeAreaView>
 `;
 
@@ -184,7 +192,7 @@ exports[`<Expenses Component/> should render a list of expenses 1`] = `
     style={
       {
         "height": "90%",
-        "padding": 10,
+        "paddingLeft": 10,
       }
     }
   >
@@ -342,17 +350,25 @@ exports[`<Expenses Component/> should render a list of expenses 1`] = `
       </View>
     </RCTScrollView>
   </View>
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
+  <View
     style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
+      {
+        "paddingLeft": 10,
+      }
     }
-  />
+  >
+    <RNCSafeAreaProvider
+      onInsetsChange={[Function]}
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
 </RCTSafeAreaView>
 `;
 
@@ -362,7 +378,7 @@ exports[`<Expenses Component/> should render an error message when there is an e
     style={
       {
         "height": "90%",
-        "padding": 10,
+        "paddingLeft": 10,
       }
     }
   >
@@ -416,137 +432,26 @@ exports[`<Expenses Component/> should render an error message when there is an e
     >
       Something went wrong
     </Text>
-    <RCTScrollView
-      ListEmptyComponent={[Function]}
-      data={
+  </View>
+  <View
+    style={
+      {
+        "paddingLeft": 10,
+      }
+    }
+  >
+    <RNCSafeAreaProvider
+      onInsetsChange={[Function]}
+      style={
         [
           {
-            "amount": 20,
-            "category": "Utilities",
-            "categoryId": "",
-            "createdAt": "12/28/2025",
-            "details": "Water bills for Feb",
-            "id": "01",
-            "name": "Water",
+            "flex": 1,
           },
-          {
-            "amount": 50,
-            "category": "Food",
-            "categoryId": "",
-            "createdAt": "12/28/2025",
-            "details": "Weekly groceries",
-            "id": "02",
-            "name": "Groceries",
-          },
+          undefined,
         ]
       }
-      getItem={[Function]}
-      getItemCount={[Function]}
-      keyExtractor={[Function]}
-      onContentSizeChange={[Function]}
-      onLayout={[Function]}
-      onMomentumScrollBegin={[Function]}
-      onMomentumScrollEnd={[Function]}
-      onScroll={[Function]}
-      onScrollBeginDrag={[Function]}
-      onScrollEndDrag={[Function]}
-      removeClippedSubviews={false}
-      renderItem={[Function]}
-      scrollEventThrottle={0.0001}
-      stickyHeaderIndices={[]}
-      viewabilityConfigCallbackPairs={[]}
-    >
-      <View>
-        <View
-          onFocusCapture={[Function]}
-          onLayout={[Function]}
-          style={null}
-        >
-          <View
-            style={
-              {
-                "borderBottomColor": "#ccc",
-                "borderBottomWidth": 1,
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-                "paddingVertical": 8,
-              }
-            }
-          >
-            <Text
-              style={
-                {
-                  "flex": 1,
-                  "fontSize": 14,
-                }
-              }
-            >
-              Water
-            </Text>
-            <Text
-              style={
-                {
-                  "flex": 1,
-                  "fontSize": 14,
-                }
-              }
-            >
-              20
-            </Text>
-          </View>
-        </View>
-        <View
-          onFocusCapture={[Function]}
-          onLayout={[Function]}
-          style={null}
-        >
-          <View
-            style={
-              {
-                "borderBottomColor": "#ccc",
-                "borderBottomWidth": 1,
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-                "paddingVertical": 8,
-              }
-            }
-          >
-            <Text
-              style={
-                {
-                  "flex": 1,
-                  "fontSize": 14,
-                }
-              }
-            >
-              Groceries
-            </Text>
-            <Text
-              style={
-                {
-                  "flex": 1,
-                  "fontSize": 14,
-                }
-              }
-            >
-              50
-            </Text>
-          </View>
-        </View>
-      </View>
-    </RCTScrollView>
+    />
   </View>
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
-    style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
-    }
-  />
 </RCTSafeAreaView>
 `;
 
@@ -556,7 +461,7 @@ exports[`<Expenses Component/> should render the empty state when there are no e
     style={
       {
         "height": "90%",
-        "padding": 10,
+        "paddingLeft": 10,
       }
     }
   >
@@ -630,23 +535,31 @@ exports[`<Expenses Component/> should render the empty state when there are no e
                 }
               }
             >
-              No expenses yet
+              No expenses yet today
             </Text>
           </View>
         </View>
       </View>
     </RCTScrollView>
   </View>
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
+  <View
     style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
+      {
+        "paddingLeft": 10,
+      }
     }
-  />
+  >
+    <RNCSafeAreaProvider
+      onInsetsChange={[Function]}
+      style={
+        [
+          {
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
 </RCTSafeAreaView>
 `;

--- a/packages/mobile/src/util.ts
+++ b/packages/mobile/src/util.ts
@@ -1,0 +1,13 @@
+export function catchError(
+  error: { [key: string]: any },
+  setError: React.Dispatch<React.SetStateAction<string>>,
+) {
+  if (!error.response || !error.response.data) {
+    console.error("No response data received from the server:", error);
+    setError(
+      "Failed to connect to the server. Confirm that you are connected to the internet and try again",
+    );
+    return;
+  }
+  setError(error.response.data.error);
+}


### PR DESCRIPTION
This PR integrates the `filterExpensesByDate` button and services into the `Expenses` screen, enabling users to filter expenses.

Currently, filtering is limited to a single date instead of a date range. Support for date-range filtering will be implemented later, as tracked in https://github.com/lubegasimon/expense-tracker-mobile/issues/102.


https://github.com/user-attachments/assets/b5e90508-bcf1-4759-bd53-146b587982b0

